### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ A Model Context Protocol (MCP) server tailored for Klever blockchain smart contr
 - 🔧 **Contract Validation**: Automatic detection of common issues and anti-patterns
 - 🚀 **Deployment Scripts**: Ready-to-use scripts for contract deployment, upgrade, and querying
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/klever-io-mcp-klever-vm).
+
 ## Quick Start
 
 Install and run instantly via npx — no cloning required:


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/klever-io-mcp-klever-vm).