### PR TITLE
[KLC-2262] improve koperator args documentation for sc

### DIFF
--- a/docs/skills/06-deployment.md
+++ b/docs/skills/06-deployment.md
@@ -26,16 +26,30 @@
 ```bash
 ~/klever-sdk/koperator sc create \
     --wasm="output/contract.wasm" \
-    --upgradeable --readable --payable --payableBySC \
+    --readable --payable --payableBySC \
+    --sign --await --result-only
+# Note: --upgradeable defaults to true (contract is upgradeable unless you omit it)
+```
+
+### Deploy with Init Arguments
+
+```bash
+~/klever-sdk/koperator sc create \
+    --wasm="output/contract.wasm" \
+    --args "bi:1000000" \
+    --args "address:klv1owner..." \
+    --args "string:MyToken" \
+    --readable --payable --payableBySC \
     --sign --await --result-only
 ```
 
 ## Upgrade
 
 ```bash
-~/klever-sdk/koperator sc update CONTRACT_ADDR \
+~/klever-sdk/koperator sc upgrade CONTRACT_ADDR \
     --wasm="output/contract.wasm" \
-    --upgradeable --readable --payable --payableBySC \
+    --upgradeable \
+    --readable --payable --payableBySC \
     --sign --await --result-only
 ```
 
@@ -43,21 +57,53 @@
 
 ```bash
 ~/klever-sdk/koperator sc invoke CONTRACT_ADDR FUNCTION_NAME \
-    --args "Type:value" \
+    --args "type:value" \
     --sign --await --result-only
 ```
 
 ### Argument Types
 
-| Type | Example |
-|---|---|
-| Address | `--args "Address:klv1abc..."` |
-| TokenIdentifier | `--args "TokenIdentifier:KLV"` |
-| String | `--args "String:hello"` |
-| u32 / u64 | `--args "u32:42"` |
-| BigUint | `--args "bi:1000000"` |
-| Bool | `--args "bool:true"` |
-| Hex | `--args "hex:deadbeef"` |
+| Type tag(s) | Rust SDK type | Example |
+|---|---|---|
+| `address`, `a` | ManagedAddress | `--args "address:klv1abc..."` |
+| `string`, `ManagedBuffer`, `TokenIdentifier`, `bytes` | ManagedBuffer / String | `--args "string:hello"` |
+| `u8`, `u16`, `u32`, `u64` | u8–u64 | `--args "u32:42"` |
+| `i8`, `i16`, `i32`, `i64` | i8–i64 | `--args "i32:-500"` |
+| `bi`, `BigUint`, `BigInt` | BigUint / BigInt | `--args "bi:1000000"` |
+| `bf`, `BigFloat` | BigFloat | `--args "bf:3.14"` |
+| `bool`, `b` | bool | `--args "bool:true"` |
+| `hex` | *(raw pass-through)* | `--args "hex:deadbeef"` |
+| `empty`, `e` | *(None / empty)* | `--args "empty:"` |
+| `number` | *(auto-detect)* | `--args "number:500"` |
+| `file`, `code`, `wasm` | *(file contents)* | `--args "file:./output/contract.wasm"` |
+
+### Option<T> (Optional Arguments)
+
+Prefix the type tag with `option` (**no colon separator**):
+
+```bash
+--args "optionu64:100"        # Some(100u64)
+--args "optionstring:hello"   # Some("hello")
+--args "optionaddress:klv1…"  # Some(address)
+--args "empty:"               # None
+```
+
+**WRONG**: ~~`Option:u32:42`~~, ~~`Option:String:hello`~~
+
+### Composite Types (List, Tuple, Variadic)
+
+No single-arg syntax. Pass each element as a separate `--args`:
+
+```bash
+# List<u32>: 3 elements
+--args "u32:10" --args "u32:20" --args "u32:30"
+
+# tuple<u32, String, Address>:
+--args "u32:42" --args "string:hello" --args "address:klv1..."
+
+# variadic<BigUint> (always last parameter):
+--args "bi:100" --args "bi:200" --args "bi:300"
+```
 
 ### Sending Payments
 
@@ -74,6 +120,19 @@
 ```
 
 **CRITICAL**: Use `--values` (plural), NEVER `--value`.
+
+### Key Flags
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `--sign` (`-s`) | false | Auto-sign without interactive prompt |
+| `--await` | false | Wait for TX to be posted on-chain |
+| `--result-only` | false | Clean JSON output (requires --await) |
+| `--create-only` (`-c`) | false | Build TX JSON without broadcasting |
+| `--nonce-check` | `current` | Nonce strategy: `current`, `first-pending`, `pending` |
+| `--upgradeable` | **true** | Contract can be upgraded (defaults to true!) |
+| `--verbose` | false | Trace-level logging |
+| `--kdaFee` | "" | Pay fees with a specific KDA token |
 
 ## Query (Read-Only Call)
 

--- a/src/knowledge/tools/index.ts
+++ b/src/knowledge/tools/index.ts
@@ -3,9 +3,17 @@
  */
 
 import koperatorKnowledge from './koperator.js';
+import koperatorAbiKnowledge from './koperator-abi.js';
+import koperatorGlobalFlagsKnowledge from './koperator-global-flags.js';
 import kscKnowledge from './ksc.js';
 import vscodeExtensionKnowledge from './vscode-extension.js';
 
-export const toolsKnowledge = [...koperatorKnowledge, ...kscKnowledge, ...vscodeExtensionKnowledge];
+export const toolsKnowledge = [
+  ...koperatorKnowledge,
+  ...koperatorAbiKnowledge,
+  ...koperatorGlobalFlagsKnowledge,
+  ...kscKnowledge,
+  ...vscodeExtensionKnowledge,
+];
 
 export default toolsKnowledge;

--- a/src/knowledge/tools/koperator-abi.ts
+++ b/src/knowledge/tools/koperator-abi.ts
@@ -1,0 +1,610 @@
+import { createKnowledgeEntry, KnowledgeEntry } from '../types.js';
+
+/**
+ * Knowledge entries for mapping ABI JSON to koperator commands and decoding output.
+ * Enables AI agents to autonomously construct koperator invocations and decode results.
+ * Sources of truth: operator-sc-invoke-create.md, operator-abi-decoding.md
+ */
+
+export const koperatorAbiKnowledge: KnowledgeEntry[] = [
+  // ──────────────────────────────────────────────────────────────────────────
+  // ENTRY 1 — ABI JSON → koperator command mapping
+  // ──────────────────────────────────────────────────────────────────────────
+  createKnowledgeEntry(
+    'documentation',
+    `# ABI JSON → Koperator Command Mapping
+
+## Overview
+
+The contract ABI (output by \`~/klever-sdk/ksc all build\` as \`output/contract.abi.json\`) defines all endpoints, their parameters, and types. This guide shows how to translate ABI definitions into koperator \`--args\` flags.
+
+## ABI Structure
+
+\`\`\`json
+{
+  "name": "my_contract",
+  "endpoints": [
+    {
+      "name": "init",
+      "inputs": [
+        { "name": "initial_supply", "type": "BigUint" },
+        { "name": "owner", "type": "Address" }
+      ],
+      "outputs": []
+    },
+    {
+      "name": "transfer",
+      "mutability": "mutable",
+      "inputs": [
+        { "name": "to", "type": "Address" },
+        { "name": "amount", "type": "BigUint" }
+      ],
+      "outputs": []
+    },
+    {
+      "name": "getBalance",
+      "mutability": "readonly",
+      "inputs": [
+        { "name": "addr", "type": "Address" }
+      ],
+      "outputs": [
+        { "name": "", "type": "BigUint" }
+      ]
+    }
+  ],
+  "types": {}
+}
+\`\`\`
+
+## ABI Type → Koperator Prefix Mapping
+
+| ABI type string | Koperator prefix | Notes |
+|----------------|-----------------|-------|
+| \`u8\` | \`u8:\` | |
+| \`u16\` | \`u16:\` | |
+| \`u32\` | \`u32:\` | |
+| \`u64\` | \`u64:\` | |
+| \`usize\` | \`u32:\` | Same encoding as u32 |
+| \`i8\` | \`i8:\` | |
+| \`i16\` | \`i16:\` | |
+| \`i32\` | \`i32:\` | |
+| \`i64\` | \`i64:\` | |
+| \`isize\` | \`i32:\` | Same encoding as i32 |
+| \`BigUint\` | \`bi:\` or \`BigUint:\` | Positive only |
+| \`BigInt\` | \`bi:\` or \`BigInt:\` | Can be negative |
+| \`BigFloat\` | \`bf:\` or \`BigFloat:\` | |
+| \`Address\` | \`address:\` | klv1… bech32 |
+| \`ManagedAddress\` | \`address:\` | Same as Address |
+| \`ManagedBuffer\` | \`string:\` | UTF-8 or raw bytes |
+| \`TokenIdentifier\` | \`string:\` | Token ID string |
+| \`bytes\` | \`string:\` | UTF-8 bytes |
+| \`BoxedBytes\` | \`string:\` | UTF-8 bytes |
+| \`&[u8]\` | \`string:\` | UTF-8 bytes |
+| \`String\` | \`string:\` | |
+| \`&str\` | \`string:\` | |
+| \`Vec<u8>\` | \`string:\` | Same as bytes |
+| \`bool\` | \`bool:\` | true or false |
+| \`Option<T>\` | \`option<prefix>:\` or \`empty:\` | See below |
+| \`List<T>\` / \`ManagedVec<T>\` | *(multiple --args)* | See below |
+| \`variadic<T>\` | *(multiple --args)* | See below |
+| \`multi<T1,T2,...>\` | *(multiple --args)* | See below |
+
+## Translating Endpoints to Commands
+
+### Step-by-step Algorithm
+
+1. **Read the endpoint name** → becomes the positional FUNCTION_NAME arg
+2. **Check mutability**: \`readonly\` → use API query; \`mutable\` → use koperator sc invoke
+3. **For each input in order**, map the ABI type to a koperator \`--args\` flag:
+   - Simple type → single \`--args "<prefix>:<value>"\`
+   - \`Option<T>\` → \`--args "option<prefix>:<value>"\` or \`--args "empty:"\` for None
+   - \`List<T>\` / \`ManagedVec<T>\` → one \`--args\` per element (type prefix from T)
+   - \`variadic<T>\` → one \`--args\` per element (always last parameter)
+   - \`multi<T1,T2,...>\` → one \`--args\` per type in the multi
+4. **Check for payable annotation** → if present, add \`--values\`
+
+### Example: ABI to Command
+
+Given this ABI endpoint:
+\`\`\`json
+{
+  "name": "configure",
+  "mutability": "mutable",
+  "inputs": [
+    { "name": "max_supply", "type": "BigUint" },
+    { "name": "token_name", "type": "bytes" },
+    { "name": "is_active", "type": "bool" },
+    { "name": "admin", "type": "Option<Address>" }
+  ]
+}
+\`\`\`
+
+Produces:
+\`\`\`bash
+~/klever-sdk/koperator sc invoke klv1contract... configure \\
+    --args "bi:1000000000000" \\
+    --args "string:MyToken" \\
+    --args "bool:true" \\
+    --args "optionaddress:klv1admin..." \\
+    --sign --await --result-only
+\`\`\`
+
+Or with None for the optional admin:
+\`\`\`bash
+~/klever-sdk/koperator sc invoke klv1contract... configure \\
+    --args "bi:1000000000000" \\
+    --args "string:MyToken" \\
+    --args "bool:true" \\
+    --args "empty:" \\
+    --sign --await --result-only
+\`\`\`
+
+## Handling \`init\` Endpoints (Constructor)
+
+The \`init\` endpoint is called during \`sc create\`. Pass its inputs as \`--args\`:
+
+\`\`\`json
+{
+  "name": "init",
+  "inputs": [
+    { "name": "initial_supply", "type": "BigUint" },
+    { "name": "owner", "type": "Address" },
+    { "name": "token_name", "type": "bytes" }
+  ]
+}
+\`\`\`
+
+\`\`\`bash
+~/klever-sdk/koperator sc create \\
+    --wasm="output/contract.wasm" \\
+    --args "bi:1000000" \\
+    --args "address:klv1owner..." \\
+    --args "string:MyToken" \\
+    --readable --payable --payableBySC \\
+    --sign --await --result-only
+\`\`\`
+
+## Handling List / Variadic Parameters
+
+### List<T> or ManagedVec<T>
+
+Each element becomes a separate \`--args\`. The contract decodes all remaining hex segments as list elements.
+
+ABI:
+\`\`\`json
+{ "name": "whitelist", "type": "List<Address>" }
+\`\`\`
+
+Command:
+\`\`\`bash
+--args "address:klv1aaa..." --args "address:klv1bbb..." --args "address:klv1ccc..."
+\`\`\`
+
+### variadic<T>
+
+Always the **last** parameter. Each value is a separate \`--args\`:
+
+ABI:
+\`\`\`json
+{ "name": "amounts", "type": "variadic<BigUint>" }
+\`\`\`
+
+Command:
+\`\`\`bash
+--args "bi:100" --args "bi:200" --args "bi:300"
+\`\`\`
+
+### multi<T1, T2, ...>
+
+Groups of types that repeat. Each type in the group is a separate \`--args\`:
+
+ABI:
+\`\`\`json
+{ "name": "pairs", "type": "variadic<multi<Address, BigUint>>" }
+\`\`\`
+
+Command (2 pairs: addr1+100, addr2+200):
+\`\`\`bash
+--args "address:klv1aaa..." --args "bi:100" \\
+--args "address:klv1bbb..." --args "bi:200"
+\`\`\`
+
+## Handling Readonly Endpoints (Queries)
+
+If \`mutability\` is \`readonly\`, use the API instead of koperator:
+
+\`\`\`json
+{
+  "name": "getBalance",
+  "mutability": "readonly",
+  "inputs": [{ "name": "addr", "type": "Address" }],
+  "outputs": [{ "name": "", "type": "BigUint" }]
+}
+\`\`\`
+
+\`\`\`bash
+# Use API query (arguments must be base64-encoded)
+curl -s 'https://api.testnet.klever.org/v1.0/sc/query' \\
+    -H 'Content-Type: application/json' \\
+    --data-raw '{
+        "ScAddress": "klv1contract...",
+        "FuncName": "getBalance",
+        "Arguments": ["<base64-encoded-address>"]
+    }'
+\`\`\`
+
+## Complete Example: Full Contract ABI → Commands
+
+\`\`\`json
+{
+  "endpoints": [
+    {
+      "name": "init",
+      "inputs": [{ "name": "cap", "type": "BigUint" }]
+    },
+    {
+      "name": "mint",
+      "mutability": "mutable",
+      "payableInTokens": ["KLV"],
+      "inputs": [{ "name": "amount", "type": "BigUint" }]
+    },
+    {
+      "name": "setRoles",
+      "mutability": "mutable",
+      "inputs": [
+        { "name": "address", "type": "Address" },
+        { "name": "roles", "type": "variadic<u32>" }
+      ]
+    },
+    {
+      "name": "totalSupply",
+      "mutability": "readonly",
+      "inputs": [],
+      "outputs": [{ "name": "", "type": "BigUint" }]
+    }
+  ]
+}
+\`\`\`
+
+### Deploy (init)
+\`\`\`bash
+~/klever-sdk/koperator sc create \\
+    --wasm="output/contract.wasm" \\
+    --args "bi:1000000" \\
+    --readable --payable --payableBySC \\
+    --sign --await --result-only
+\`\`\`
+
+### mint (payable)
+\`\`\`bash
+~/klever-sdk/koperator sc invoke klv1contract... mint \\
+    --args "bi:500" \\
+    --values "KLV=1000000" \\
+    --sign --await --result-only
+\`\`\`
+
+### setRoles (variadic tail)
+\`\`\`bash
+~/klever-sdk/koperator sc invoke klv1contract... setRoles \\
+    --args "address:klv1user..." \\
+    --args "u32:1" --args "u32:2" --args "u32:4" \\
+    --sign --await --result-only
+\`\`\`
+
+### totalSupply (readonly → API query)
+\`\`\`bash
+curl -s 'https://api.testnet.klever.org/v1.0/sc/query' \\
+    -d '{"ScAddress":"klv1contract...","FuncName":"totalSupply","Arguments":[]}'
+\`\`\``,
+    {
+      title: 'ABI JSON to Koperator Command Mapping',
+      description:
+        'How to translate contract ABI endpoint definitions into koperator --args flags. Covers init, mutable, readonly, List, variadic, multi, Option.',
+      tags: [
+        'koperator',
+        'abi',
+        'mapping',
+        'endpoints',
+        'arguments',
+        'translation',
+        'automation',
+        'reference',
+        'smart-contract',
+      ],
+      language: 'bash',
+      relevanceScore: 1.0,
+      contractType: 'any',
+      author: 'klever-mcp',
+    }
+  ),
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // ENTRY 2 — sc parse-output: ABI-based output decoding
+  // ──────────────────────────────────────────────────────────────────────────
+  createKnowledgeEntry(
+    'documentation',
+    `# Decoding Smart Contract Output: sc parse-output
+
+## Command Overview
+
+\`operator sc parse-output\` (alias: \`sc scpo\`) decodes raw smart contract output using an ABI file.
+
+\`\`\`bash
+~/klever-sdk/koperator sc parse-output <mode> <endpoint-name> \\
+    --abi <path-to-abi.json> \\
+    --raw-output <data-string> \\
+    [--result-only --await]
+\`\`\`
+
+### Positional Arguments
+
+| Position | Required | Description |
+|----------|----------|-------------|
+| 0 | Yes | Decode mode: \`hex\` or \`query\` |
+| 1 | Yes | Endpoint name (case-sensitive, must match ABI exactly) |
+
+### Command Flags
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| \`--abi\` | string | Yes | Path to the contract's ABI JSON file |
+| \`--raw-output\` | string | Yes | Raw output data (hex string or base64) |
+
+## Decode Modes
+
+| Mode | Input format | When to use |
+|------|-------------|-------------|
+| \`hex\` | Raw hex string (e.g. \`0000000a\`) | TX results, storage reads, manual hex data |
+| \`query\` | Base64 string (e.g. \`AAAACg==\`) | Output from \`/vm/query\` API (returns base64) |
+
+\`query\` mode: base64 decode → hex encode → hex decode. Both modes converge on the same pipeline.
+
+## ABI File Structure
+
+The decoder uses only the \`endpoints\` and \`types\` sections:
+
+\`\`\`json
+{
+  "name": "MyContract",
+  "endpoints": [
+    {
+      "name": "getBalance",
+      "mutability": "readonly",
+      "inputs": [{ "name": "addr", "type": "Address" }],
+      "outputs": [{ "type": "BigUint" }]
+    }
+  ],
+  "types": {
+    "TokenInfo": {
+      "type": "struct",
+      "fields": [
+        { "name": "id", "type": "TokenIdentifier" },
+        { "name": "amount", "type": "BigUint" },
+        { "name": "frozen", "type": "bool" }
+      ]
+    }
+  }
+}
+\`\`\`
+
+For decoding, only the \`outputs\` array matters. Custom structs are resolved from the \`types\` map.
+
+## Type Categories for Decoding
+
+### Fixed-Length Types (consume fixed hex width)
+
+| Type | Hex chars | Bytes |
+|------|-----------|-------|
+| \`u8\` / \`i8\` | 2 | 1 |
+| \`u16\` / \`i16\` | 4 | 2 |
+| \`u32\` / \`i32\` / \`usize\` / \`isize\` | 8 | 4 |
+| \`u64\` / \`i64\` | 16 | 8 |
+| \`bool\` | 2 | 1 (\`01\` = true, else false) |
+| \`Address\` | 64 | 32 (always fixed, → bech32 \`klv1…\`) |
+
+### Dynamic-Length Types (variable size, length-prefixed when nested)
+
+\`ManagedBuffer\`, \`TokenIdentifier\`, \`bytes\`, \`BoxedBytes\`, \`String\`, \`&str\`, \`Vec<u8>\`, \`&[u8]\`, \`BigInt\`, \`BigUint\`, \`BigFloat\`
+
+- **Top-level** (sole output): entire hex is the data, no length prefix
+- **Nested** (in List/Tuple/Struct/Option): 4-byte (8 hex) length prefix before data
+
+\`\`\`
+Nested string "hello":  [00000005][68656c6c6f]
+                          ^ 5 bytes  ^ "hello"
+\`\`\`
+
+### Wrapper / Composite Types
+
+| Wrapper | Decoding rule |
+|---------|---------------|
+| \`List<T>\` | Elements sequential until hex exhausted. Dynamic T gets length prefix per element. |
+| \`Option<T>\` | 1-byte flag: empty = None, \`01\` = Some + nested T |
+| \`tuple<T1,T2,...>\` | Each element decoded in order per its type |
+| \`variadic<T>\` | Delegates to inner type T |
+| Custom struct | Fields decoded in ABI order; dynamic fields get length prefix |
+
+### Type Resolution Order
+
+1. Split at \`<\` → match wrapper (List, Option, tuple, variadic)
+2. Match built-in primitive/dynamic type
+3. Look up in ABI \`types\` map (custom struct)
+4. Error: \`"type X not found in provided abi"\`
+
+## Decoding Examples
+
+### BigUint from hex
+\`\`\`bash
+# ABI: { "name": "getTotal", "outputs": [{ "type": "BigUint" }] }
+~/klever-sdk/koperator sc parse-output hex getTotal \\
+    --abi ./contract.abi.json \\
+    --raw-output "1388"
+# Output: 5000
+\`\`\`
+
+### BigUint from VM query (base64)
+\`\`\`bash
+~/klever-sdk/koperator sc parse-output query getTotal \\
+    --abi ./contract.abi.json \\
+    --raw-output "E4g="
+# Output: 5000 (base64 → hex 1388 → 5000)
+\`\`\`
+
+### Address
+\`\`\`bash
+~/klever-sdk/koperator sc parse-output hex getOwner \\
+    --abi ./contract.abi.json \\
+    --raw-output "0139472eff6886771a982f3083da5d421f24c29181e63888228dc81ca60d69e1"
+# Output: klv1… bech32 address
+\`\`\`
+
+### String / TokenIdentifier
+\`\`\`bash
+~/klever-sdk/koperator sc parse-output hex getName \\
+    --abi ./contract.abi.json \\
+    --raw-output "4b4c56"
+# Output: KLV
+\`\`\`
+
+### List<u32>
+\`\`\`bash
+# Each u32 is 8 hex chars (fixed-width nested):
+# 0000000a = 10, 00000014 = 20, 00000064 = 100
+~/klever-sdk/koperator sc parse-output hex getValues \\
+    --abi ./contract.abi.json \\
+    --raw-output "0000000a0000001400000064"
+# Output: [10, 20, 100]
+\`\`\`
+
+### List<BigUint> (dynamic-length elements)
+\`\`\`bash
+# Each BigUint is length-prefixed:
+# 00000002 1388  → 2 bytes → 5000
+# 00000003 07a120 → 3 bytes → 500000
+~/klever-sdk/koperator sc parse-output hex getBalances \\
+    --abi ./contract.abi.json \\
+    --raw-output "0000000213880000000307a120"
+# Output: [5000, 500000]
+\`\`\`
+
+### Option<BigUint>
+\`\`\`bash
+# Some(5000): 01 + length(00000002) + data(1388)
+~/klever-sdk/koperator sc parse-output hex getReward \\
+    --abi ./contract.abi.json \\
+    --raw-output "01000000021388"
+# Output: 5000
+
+# None (empty string):
+~/klever-sdk/koperator sc parse-output hex getReward \\
+    --abi ./contract.abi.json \\
+    --raw-output ""
+# Output: <nil>
+\`\`\`
+
+### Option<u32>
+\`\`\`bash
+# Some(42): 01 + 0000002a (nested u32, fixed 4 bytes)
+~/klever-sdk/koperator sc parse-output hex getLimit \\
+    --abi ./contract.abi.json \\
+    --raw-output "010000002a"
+# Output: 42
+\`\`\`
+
+### Custom Struct
+\`\`\`bash
+# ABI types: TokenInfo { id: TokenIdentifier, amount: BigUint, frozen: bool }
+# id = "KLV": length(00000003) + 4b4c56
+# amount = 1000000: length(00000003) + 0f4240
+# frozen = false: 00
+~/klever-sdk/koperator sc parse-output hex getInfo \\
+    --abi ./contract.abi.json \\
+    --raw-output "000000034b4c5600000003 0f424000"
+# Output: { "id": "KLV", "amount": 1000000, "frozen": false }
+\`\`\`
+
+### Scripting-Friendly
+\`\`\`bash
+VALUE=$(~/klever-sdk/koperator sc parse-output hex getTotal \\
+    --abi ./contract.abi.json \\
+    --raw-output "1388" \\
+    --result-only --await)
+echo "Total: $VALUE"
+\`\`\`
+
+## Obtaining Raw Output Data
+
+### From VM query (readonly endpoints)
+\`\`\`bash
+RAW=$(curl -s -X POST https://node.testnet.klever.org/vm/query \\
+    -H "Content-Type: application/json" \\
+    -d '{"scAddress":"klv1contract...","funcName":"getTotal","args":[]}' \\
+    | jq -r '.data.returnData[0]')
+
+~/klever-sdk/koperator sc parse-output query getTotal \\
+    --abi ./contract.abi.json \\
+    --raw-output "$RAW" \\
+    --result-only --await
+\`\`\`
+
+### From transaction result (mutable endpoints)
+Extract hex from the TX result's smartContractResults, then use \`hex\` mode.
+
+## Decision Tree for Agents
+
+\`\`\`
+Is the data from /vm/query?
+  ├── YES → mode = "query", --raw-output = base64 from returnData
+  └── NO  → Is it hex from a TX result or storage?
+              ├── YES → mode = "hex", --raw-output = hex string
+              └── NO  → Convert to hex first, then use "hex" mode
+\`\`\`
+
+## Error Reference
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| \`invalid file path provided\` | --abi empty or missing | Supply valid path |
+| \`empty smart contract output not allowed\` | --raw-output empty | Provide hex or base64 data |
+| \`invalid parse option\` | Mode is not \`hex\` or \`query\` | Use \`hex\` or \`query\` |
+| \`endpoint <name> not found\` | Name doesn't match ABI | Check exact case-sensitive name |
+| \`invalid base64 string\` | Bad base64 in query mode | Verify base64 encoding |
+| \`type <X> not found in provided abi\` | Unknown type | Add type to ABI \`types\` map |
+| \`error decoding list item\` | Data/type mismatch | Verify hex matches List<T> structure |
+
+## Important Notes for Agents
+
+1. **Endpoint names are case-sensitive** — must match ABI exactly
+2. **ABI file must be on disk** — no inline ABI mode; reference a local file
+3. **One --raw-output per invocation** — decode multiple outputs with multiple runs
+4. **No spaces in hex** — entire hex string must be contiguous
+5. **Decoded type depends on ABI** — outdated ABI = wrong/failed decoding
+6. **Use query mode for readonly** endpoints with /vm/query; hex mode for TX results`,
+    {
+      title: 'Decoding Smart Contract Output with sc parse-output',
+      description:
+        'Complete reference for sc parse-output: decode modes (hex/query), ABI type system, fixed vs dynamic types, length prefixes, List/Option/Tuple/Struct decoding, error reference, agent workflow',
+      tags: [
+        'koperator',
+        'abi',
+        'decode',
+        'parse-output',
+        'hex',
+        'query',
+        'output',
+        'types',
+        'list',
+        'option',
+        'struct',
+        'reference',
+        'smart-contract',
+      ],
+      language: 'bash',
+      relevanceScore: 1.0,
+      contractType: 'any',
+      author: 'klever-mcp',
+    }
+  ),
+];
+
+export default koperatorAbiKnowledge;

--- a/src/knowledge/tools/koperator-abi.ts
+++ b/src/knowledge/tools/koperator-abi.ts
@@ -494,12 +494,20 @@ Nested string "hello":  [00000005][68656c6c6f]
     --abi ./contract.abi.json \\
     --raw-output "01000000021388"
 # Output: 5000
+\`\`\`
 
-# None (empty string):
-~/klever-sdk/koperator sc parse-output hex getReward \\
-    --abi ./contract.abi.json \\
-    --raw-output ""
-# Output: <nil>
+**Option None:** At the encoding level, Option None is an empty byte sequence.
+However, \`--raw-output ""\` triggers the CLI error \`"empty smart contract output not allowed"\`.
+Detect None **before** calling parse-output by checking if the VM query \`returnData\` array
+is empty or the element is an empty string:
+\`\`\`bash
+RAW=$(curl -s ... | jq -r '.data.returnData[0] // empty')
+if [ -z "$RAW" ]; then
+  echo "None"  # Option is None — nothing to decode
+else
+  ~/klever-sdk/koperator sc parse-output query getReward \\
+      --abi ./contract.abi.json --raw-output "$RAW"
+fi
 \`\`\`
 
 ### Option<u32>
@@ -519,7 +527,7 @@ Nested string "hello":  [00000005][68656c6c6f]
 # frozen = false: 00
 ~/klever-sdk/koperator sc parse-output hex getInfo \\
     --abi ./contract.abi.json \\
-    --raw-output "000000034b4c5600000003 0f424000"
+    --raw-output "000000034b4c56000000030f424000"
 # Output: { "id": "KLV", "amount": 1000000, "frozen": false }
 \`\`\`
 
@@ -565,7 +573,7 @@ Is the data from /vm/query?
 | Error | Cause | Fix |
 |-------|-------|-----|
 | \`invalid file path provided\` | --abi empty or missing | Supply valid path |
-| \`empty smart contract output not allowed\` | --raw-output empty | Provide hex or base64 data |
+| \`empty smart contract output not allowed\` | --raw-output empty | Provide hex or base64 data. For Option None, detect empty data before calling parse-output (see Option examples above) |
 | \`invalid parse option\` | Mode is not \`hex\` or \`query\` | Use \`hex\` or \`query\` |
 | \`endpoint <name> not found\` | Name doesn't match ABI | Check exact case-sensitive name |
 | \`invalid base64 string\` | Bad base64 in query mode | Verify base64 encoding |

--- a/src/knowledge/tools/koperator-global-flags.ts
+++ b/src/knowledge/tools/koperator-global-flags.ts
@@ -1,0 +1,458 @@
+import { createKnowledgeEntry, KnowledgeEntry } from '../types.js';
+
+/**
+ * Detailed documentation for all koperator global (persistent) flags.
+ * Source of truth: operator-global-flags.md (extracted from koperator source code)
+ */
+
+export const koperatorGlobalFlagsKnowledge: KnowledgeEntry[] = [
+  // ──────────────────────────────────────────────────────────────────────────
+  // ENTRY 1 — Authentication, Network & Transaction Construction Flags
+  // ──────────────────────────────────────────────────────────────────────────
+  createKnowledgeEntry(
+    'documentation',
+    `# Koperator Global Flags: Authentication, Network & Transaction Construction
+
+All global (persistent) flags propagate to every subcommand (\`sc\`, \`send\`, \`kda\`, \`validator\`, \`account\`, etc.).
+
+Before any command runs, a startup hook:
+1. Validates flag combinations (e.g. \`--args\` and \`--message\` cannot coexist).
+2. Loads the wallet PEM file, deriving the signer address and private key.
+3. Auto-fetches the account nonce from the node (unless \`--nonce\` was explicitly set).
+4. Loads optional multi-sign keys.
+5. Reads a \`.env\` file (via godotenv) from the current working directory.
+
+---
+
+## Authentication & Key Management
+
+### --key-file / -k
+| Property | Value |
+|----------|-------|
+| Type | string |
+| Short | \`-k\` |
+| Default | \`./walletKey.pem\` |
+
+Path to the wallet PEM file (Ed25519 private key). The public key and bech32 address (\`klv1…\`) are derived automatically.
+
+\`\`\`bash
+~/klever-sdk/koperator sc invoke klv1... myFunc --key-file /path/to/myWallet.pem
+\`\`\`
+
+If the default \`./walletKey.pem\` is not found and no \`-k\` is provided, the operator logs a warning but continues (some read-only commands don't require a key).
+
+### --password / -p
+| Property | Value |
+|----------|-------|
+| Type | string |
+| Short | \`-p\` |
+| Default | \`""\` (no encryption) |
+
+Password to decrypt an encrypted PEM file. Three modes:
+
+| Usage | Behavior |
+|-------|----------|
+| \`--password=MY_SECRET\` | Uses the literal password string. |
+| \`--password\` (no value) | Prompts interactively on stdin (hidden input). |
+| *(omitted)* | No password — PEM is assumed unencrypted. |
+
+> **Security for automation:** Prefer \`--password-file\` over \`--password\` — CLI args are visible in process listings.
+
+### --password-file
+| Property | Value |
+|----------|-------|
+| Type | string |
+| Default | \`""\` |
+
+Path to a plaintext file containing the PEM password. Trailing newlines are stripped. **Recommended for automation and scripting.**
+
+\`\`\`bash
+~/klever-sdk/koperator sc invoke klv1... myFunc --password-file /secrets/wallet-password.txt
+\`\`\`
+
+If both \`--password\` and \`--password-file\` are provided, \`--password-file\` takes precedence.
+
+### --multi-files / -m
+| Property | Value |
+|----------|-------|
+| Type | string array (repeatable) |
+| Short | \`-m\` |
+| Default | \`[]\` |
+
+Additional PEM key files for **multi-signature** workflows. Each additional signature is appended to the transaction.
+
+\`\`\`bash
+~/klever-sdk/koperator sc invoke klv1... myFunc \\
+    --key-file ./signer1.pem \\
+    -m ./signer2.pem \\
+    -m ./signer3.pem
+\`\`\`
+
+Each additional key uses the same \`--password\` / \`--password-file\` as the primary key.
+
+---
+
+## Network & Node Connection
+
+### --node / -n
+| Property | Value |
+|----------|-------|
+| Type | string |
+| Short | \`-n\` |
+| Default | \`http://localhost:8080\` |
+
+URL of the Klever node API. All TX creation, broadcasting, account queries, and block lookups go to this endpoint.
+
+\`\`\`bash
+# Mainnet
+~/klever-sdk/koperator sc invoke klv1... myFunc --node https://node.mainnet.klever.org
+
+# Testnet
+~/klever-sdk/koperator sc invoke klv1... myFunc -n https://node.testnet.klever.org
+\`\`\`
+
+Node API routes used:
+- \`POST /transaction/send\` — create the transaction object
+- \`POST /transaction/broadcast\` — broadcast a signed transaction
+- \`GET /address/{address}/nonce\` — fetch account nonce
+- \`GET /transaction/{hash}\` — look up a transaction by hash
+- \`GET /block/by-nonce/{nonce}\` — fetch a block
+
+### KLEVER_NODE Environment Variable
+
+The \`KLEVER_NODE\` env var overrides the default node URL. Loaded at startup via godotenv (reads \`.env\` file if present). The \`--node\` flag takes final precedence if explicitly passed.
+
+\`\`\`bash
+# In .env file:
+KLEVER_NODE=https://node.testnet.klever.org
+
+# Or export:
+export KLEVER_NODE=https://node.testnet.klever.org
+~/klever-sdk/koperator sc invoke klv1... myFunc  # uses testnet without --node
+\`\`\`
+
+---
+
+## Transaction Construction
+
+### --nonce
+| Property | Value |
+|----------|-------|
+| Type | uint64 |
+| Default | \`0\` (auto-fetch) |
+
+Explicitly set the TX nonce. When \`0\` (default), the operator auto-fetches the nonce from the node using the strategy set by \`--nonce-check\`.
+
+\`\`\`bash
+~/klever-sdk/koperator sc invoke klv1... myFunc --nonce 42
+\`\`\`
+
+Use when you need to override or replay a specific nonce, or when running offline with \`--create-only\`.
+
+### --nonce-check
+| Property | Value |
+|----------|-------|
+| Type | string |
+| Default | \`current\` |
+| Valid values | \`current\`, \`first-pending\`, \`pending\` |
+
+Controls which nonce is fetched when \`--nonce=0\` (auto-fetch). The node response provides three values:
+
+| Strategy | Node field | Use case |
+|----------|-----------|----------|
+| \`current\` | \`nonce\` | Default — current confirmed nonce. Normal single-TX operations. |
+| \`first-pending\` | \`firstPendingNonce\` | First pending nonce in mempool. Replacing a stuck TX. |
+| \`pending\` | \`nonce + txPending\` | Confirmed nonce + pending count. Queuing multiple TXs rapidly. |
+
+\`\`\`bash
+# Queue 3 TXs rapidly
+~/klever-sdk/koperator sc invoke klv1... func1 --nonce-check pending --sign &
+~/klever-sdk/koperator sc invoke klv1... func2 --nonce-check pending --sign &
+~/klever-sdk/koperator sc invoke klv1... func3 --nonce-check pending --sign &
+\`\`\`
+
+### --message
+| Property | Value |
+|----------|-------|
+| Type | string array (repeatable) |
+| Default | \`nil\` |
+
+Sets raw data/message bytes on the transaction. Each \`--message\` value becomes one entry in the TX \`Data\` field.
+
+\`\`\`bash
+~/klever-sdk/koperator sc invoke klv1... --message "myRawData"
+\`\`\`
+
+> **Mutually exclusive with \`--args\`:** Error: \`"can only use args or messages flag, not both"\`
+
+### --fromAddress
+| Property | Value |
+|----------|-------|
+| Type | string |
+| Default | \`""\` (uses signer address) |
+
+Overrides the \`Sender\` field in the transaction. The nonce is also fetched for this address instead of the signer. Useful for **permissioned accounts** where one key signs on behalf of another.
+
+\`\`\`bash
+~/klever-sdk/koperator sc invoke klv1... myFunc \\
+    --key-file ./delegateKey.pem \\
+    --fromAddress klv1ownerAddress...
+\`\`\`
+
+### --permID
+| Property | Value |
+|----------|-------|
+| Type | int32 |
+| Default | \`0\` |
+
+Permission group ID. Klever accounts can have multiple permission groups. Default \`0\` = owner permission (primary key).
+
+\`\`\`bash
+~/klever-sdk/koperator sc invoke klv1... myFunc --permID 2 --key-file ./permKey.pem
+\`\`\`
+
+### --kdaFee
+| Property | Value |
+|----------|-------|
+| Type | string |
+| Default | \`""\` (pay with KLV) |
+
+A KDA token identifier to pay TX fees instead of KLV.
+
+\`\`\`bash
+~/klever-sdk/koperator sc invoke klv1... myFunc --kdaFee KDA-ab12
+\`\`\``,
+    {
+      title: 'Koperator Global Flags: Authentication, Network & Transaction Construction',
+      description:
+        'Detailed reference for --key-file, --password, --password-file, --multi-files, --node, KLEVER_NODE, --nonce, --nonce-check, --message, --fromAddress, --permID, --kdaFee',
+      tags: [
+        'koperator',
+        'global-flags',
+        'authentication',
+        'key-file',
+        'password',
+        'multi-sign',
+        'node',
+        'network',
+        'nonce',
+        'transaction',
+        'reference',
+      ],
+      language: 'bash',
+      relevanceScore: 0.95,
+      contractType: 'any',
+      author: 'klever-mcp',
+    }
+  ),
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // ENTRY 2 — Signing, Broadcasting, Output Control & Automation Patterns
+  // ──────────────────────────────────────────────────────────────────────────
+  createKnowledgeEntry(
+    'documentation',
+    `# Koperator Global Flags: Signing, Output Control & Automation
+
+## Signing & Broadcasting
+
+### --sign / -s
+| Property | Value |
+|----------|-------|
+| Type | bool |
+| Short | \`-s\` |
+| Default | \`false\` |
+
+Auto-signs the transaction without interactive confirmation.
+
+**Without --sign** (default): Displays full TX details and prompts:
+\`\`\`
+Requested Transaction Details:
+{...formatted JSON...}
+Please carefully review the transaction above.
+Would you like to sign this transaction? (yes/no)
+\`\`\`
+Valid confirmations: \`y\`, \`Y\`, \`yes\`, \`Yes\`, \`YES\`.
+Valid rejections: \`n\`, \`N\`, \`no\`, \`No\`, \`NO\`.
+
+**With --sign**: Skips the prompt entirely and signs immediately.
+
+> **For automation:** Always use \`--sign\` when calling koperator programmatically — interactive prompts will hang the process.
+
+### --create-only / -c
+| Property | Value |
+|----------|-------|
+| Type | bool |
+| Short | \`-c\` |
+| Default | \`false\` |
+
+Builds and signs the TX but does **not** broadcast it. The complete signed TX JSON is printed to stdout.
+
+\`\`\`bash
+# Generate signed TX for later broadcast
+~/klever-sdk/koperator sc invoke klv1... myFunc --create-only --sign > tx.json
+\`\`\`
+
+Useful for:
+- Offline signing workflows
+- Inspecting the TX before broadcasting
+- Multi-step multi-sig processes where the TX is passed between signers
+
+When active, logging is suppressed (set to LogNone).
+
+### Transaction Signing Flow
+
+The full lifecycle of a transaction:
+
+\`\`\`
+1. Build request JSON (sender, nonce, contract data, etc.)
+       ↓
+2. POST /transaction/send → node returns a Transaction object
+       ↓
+3. If NOT --sign: display TX and prompt for confirmation
+   If --sign: skip confirmation
+       ↓
+4. Sign with primary key (Ed25519)
+       ↓
+5. For each --multi-files key: add additional signature
+       ↓
+6. If --create-only: dump signed TX JSON to stdout → STOP
+       ↓
+7. POST /transaction/broadcast → node returns txHash
+       ↓
+8. If --await: poll GET /transaction/{hash} every 2s (up to 20s)
+   until status ≠ pending
+       ↓
+9. Display TX details with block info
+\`\`\`
+
+---
+
+## Output Control
+
+### --await
+| Property | Value |
+|----------|-------|
+| Type | bool |
+| Default | \`false\` |
+
+Waits for the TX to be processed on-chain after broadcasting. Polls the node every **2 seconds** for up to **10 attempts** (≈20 seconds). Once TX status is no longer \`pending\`, fetches the block and displays full details.
+
+If the TX is not found or still pending after timeout: error \`"transaction not found within the specified timeout"\`.
+
+### --result-only
+| Property | Value |
+|----------|-------|
+| Type | bool |
+| Default | \`false\` |
+
+Suppresses all informational logging and prints **only** the TX result. Designed for programmatic consumption and piping.
+
+**Constraint:** Requires \`--await\`. Without it: error \`"await flag is required to use result-only"\`.
+
+\`\`\`bash
+TX_HASH=$(~/klever-sdk/koperator sc invoke klv1... myFunc --sign --await --result-only)
+\`\`\`
+
+> **Mutually exclusive with \`--verbose\`.**
+
+### --verbose
+| Property | Value |
+|----------|-------|
+| Type | bool |
+| Default | \`false\` |
+
+Enables trace-level logging for debugging. Shows detailed internal operations, HTTP requests, encoding steps, etc.
+
+> **Mutually exclusive with \`--result-only\`.**
+
+---
+
+## Mutual Exclusivity & Constraints
+
+| Constraint | Error if violated |
+|------------|-------------------|
+| \`--args\` and \`--message\` cannot both be provided | \`"can only use args or messages flag, not both"\` |
+| \`--result-only\` requires \`--await\` | \`"await flag is required to use result-only"\` |
+| \`--result-only\` and \`--verbose\` are mutually exclusive | *(enforced by cobra)* |
+
+---
+
+## Automation Patterns (MCP / AI Agent)
+
+### Standard automated invocation
+\`\`\`bash
+~/klever-sdk/koperator <subcommand> [args...] \\
+    --key-file <path> \\
+    --password-file <path> \\
+    --node <url> \\
+    --sign \\
+    --await \\
+    --result-only
+\`\`\`
+
+### Dry-run / inspection without broadcasting
+\`\`\`bash
+~/klever-sdk/koperator <subcommand> [args...] \\
+    --key-file <path> \\
+    --create-only \\
+    --sign
+\`\`\`
+
+### Rapid TX queuing (multiple TXs without waiting)
+\`\`\`bash
+~/klever-sdk/koperator <subcommand> [args...] \\
+    --nonce-check pending \\
+    --sign
+\`\`\`
+
+### Multi-signature workflow
+\`\`\`bash
+~/klever-sdk/koperator sc invoke klv1... myFunc \\
+    --key-file ./signer1.pem \\
+    -m ./signer2.pem \\
+    -m ./signer3.pem \\
+    --sign --await --result-only
+\`\`\`
+
+### Permissioned account (delegated signing)
+\`\`\`bash
+~/klever-sdk/koperator sc invoke klv1... myFunc \\
+    --key-file ./delegateKey.pem \\
+    --fromAddress klv1ownerAddress... \\
+    --permID 2 \\
+    --sign --await --result-only
+\`\`\`
+
+### Encrypted PEM in automation
+\`\`\`bash
+~/klever-sdk/koperator sc invoke klv1... myFunc \\
+    --key-file ./encrypted-wallet.pem \\
+    --password-file /run/secrets/wallet-pass \\
+    --sign --await --result-only
+\`\`\``,
+    {
+      title: 'Koperator Global Flags: Signing, Output Control & Automation',
+      description:
+        'Detailed reference for --sign, --create-only, --await, --result-only, --verbose, TX signing flow, mutual exclusivity constraints, and automation patterns',
+      tags: [
+        'koperator',
+        'global-flags',
+        'sign',
+        'create-only',
+        'await',
+        'result-only',
+        'verbose',
+        'automation',
+        'signing-flow',
+        'multi-sig',
+        'reference',
+      ],
+      language: 'bash',
+      relevanceScore: 0.95,
+      contractType: 'any',
+      author: 'klever-mcp',
+    }
+  ),
+];
+
+export default koperatorGlobalFlagsKnowledge;

--- a/src/knowledge/tools/koperator.ts
+++ b/src/knowledge/tools/koperator.ts
@@ -2,76 +2,114 @@ import { createKnowledgeEntry, KnowledgeEntry } from '../types.js';
 
 /**
  * Koperator tool documentation and usage patterns
+ *
+ * Source of truth: operator-sc-invoke-create.md (extracted from koperator source code)
  */
 
 export const koperatorKnowledge: KnowledgeEntry[] = [
-  // CRITICAL: Correct Koperator Syntax
+  // ──────────────────────────────────────────────────────────────────────────
+  // ENTRY 1 — CRITICAL: Correct Koperator Syntax
+  // ──────────────────────────────────────────────────────────────────────────
   createKnowledgeEntry(
     'deployment_tool',
     `# ⚠️ CRITICAL: Correct Koperator Command Syntax ⚠️
 
-## ALWAYS Use This Format for sc invoke:
+## sc invoke — ALWAYS Use This Format:
 
 \`\`\`bash
-# CORRECT FORMAT:
 ~/klever-sdk/koperator \\
     --key-file="$HOME/klever-sdk/walletKey.pem" \\
     sc invoke CONTRACT_ADDRESS FUNCTION_NAME \\
     --args "type:value" \\
     --values "KLV=amount" \\
-    --await --sign --result-only
+    --sign --await --result-only
 \`\`\`
 
+CONTRACT_ADDRESS (positional arg 0, required) and FUNCTION_NAME (positional arg 1) are NOT flags.
+If FUNCTION_NAME is omitted you must provide \`--message\` with raw data instead.
+\`--args\` and \`--message\` are **mutually exclusive** — never pass both.
+
+## sc create — Deploy Format:
+
+\`\`\`bash
+~/klever-sdk/koperator \\
+    --key-file="$HOME/klever-sdk/walletKey.pem" \\
+    sc create \\
+    --wasm="output/contract.wasm" \\
+    --args "type:value" \\
+    --upgradeable --readable --payable --payableBySC \\
+    --sign --await --result-only
+\`\`\`
+
+Note: \`--upgradeable\` **defaults to true**. Omit it only when you want an immutable contract.
+
 ## ❌ NEVER USE These Wrong Patterns:
-- \`--contract="address"\` ❌ WRONG - use positional argument
-- \`--function="name"\` ❌ WRONG - use positional argument
-- \`--value="amount"\` ❌ WRONG - use --values "KLV=amount"
-- \`--kdaFee="KLV"\` ❌ WRONG - does not exist
-- \`--token-transfers\` ❌ WRONG - use --values
+- \`--contract="address"\` ❌ WRONG — use positional argument
+- \`--function="name"\` ❌ WRONG — use positional argument
+- \`--value="amount"\` ❌ WRONG — use \`--values "KLV=amount"\` (plural)
+- \`--token-transfers\` ❌ WRONG — use \`--values\`
+- \`Option:String:hello\` ❌ WRONG — use \`optionstring:hello\` (no colon between option and type)
+- \`List:u32:1,u32:2\` ❌ WRONG — no single-arg list syntax; pass each element as separate \`--args\`
 
 ## Correct Examples:
 
 ### Simple Function Call
 \`\`\`bash
 ~/klever-sdk/koperator sc invoke klv1abc... myFunction \\
-    --await --sign --result-only
+    --sign --await --result-only
 \`\`\`
 
 ### With Arguments
 \`\`\`bash
 ~/klever-sdk/koperator sc invoke klv1abc... transfer \\
-    --args "Address:klv1xyz..." \\
+    --args "address:klv1xyz..." \\
     --args "bi:1000000" \\
-    --await --sign --result-only
+    --sign --await --result-only
 \`\`\`
 
 ### With Payment
 \`\`\`bash
 ~/klever-sdk/koperator sc invoke klv1abc... stake \\
     --values "KLV=10000000" \\
-    --await --sign --result-only
+    --sign --await --result-only
 \`\`\`
 
-## Key Parameters Explained:
-- Positional Args: CONTRACT_ADDRESS and FUNCTION_NAME come first (no flags)
-- \`--args\`: Each argument needs its own --args flag with type prefix
-- \`--values\`: For sending tokens (KLV, KFI, or KDA tokens)
-- \`--await\`: Wait for transaction confirmation
-- \`--sign\`: Sign the transaction
-- \`--result-only\`: Show only the transaction result (clean JSON output without logs)
+### With Optional Argument
+\`\`\`bash
+~/klever-sdk/koperator sc invoke klv1abc... setConfig \\
+    --args "optionu64:100" \\
+    --args "optionstring:newName" \\
+    --sign --await --result-only
+\`\`\`
+
+### Deploy with Init Arguments
+\`\`\`bash
+~/klever-sdk/koperator sc create \\
+    --wasm="output/contract.wasm" \\
+    --args "BigUint:1000000" \\
+    --args "address:klv1owner..." \\
+    --payable --payableBySC --readable \\
+    --sign --await --result-only
+\`\`\`
 
 ## 🚨 CRITICAL for Unattended Scripts:
-When using koperator in automated/unattended scripts, you MUST use these three flags together:
-- \`--sign\`: Signs and broadcasts the transaction without user interaction
-- \`--await\`: Waits for the transaction to be included in a block
-- \`--result-only\`: Returns only clean JSON result without extra output
+You MUST use these three flags together:
+- \`--sign\` (-s): Signs and broadcasts without user interaction
+- \`--await\`: Waits for the TX to be posted on-chain
+- \`--result-only\`: Returns only clean JSON result (requires --await)
 
-Without these flags, scripts will hang waiting for user input or produce unparseable output!`,
+Without these flags, scripts will hang waiting for user input or produce unparseable output!
+
+## Other Important Global Flags:
+- \`--create-only\` (-c): Build the TX JSON without broadcasting (offline signing)
+- \`--nonce-check\`: Nonce strategy — \`current\` (default), \`first-pending\`, or \`pending\`
+- \`--kdaFee\`: Pay fees with a specific KDA token
+- \`--verbose\`: Enable trace-level logging for debugging`,
     {
       title: 'CRITICAL: Correct Koperator Syntax - READ THIS FIRST',
       description:
-        'The ONLY correct way to use koperator sc invoke - NEVER use --contract, --function, --value. Always include --result-only for clean output',
-      tags: ['koperator', 'critical', 'syntax', 'sc-invoke', 'commands'],
+        'The ONLY correct way to use koperator sc invoke and sc create. Covers positional args, option syntax, --message vs --args, and automation flags.',
+      tags: ['koperator', 'critical', 'syntax', 'sc-invoke', 'sc-create', 'commands', 'smart-contract'],
       language: 'bash',
       relevanceScore: 1.0,
       contractType: 'any',
@@ -79,81 +117,136 @@ Without these flags, scripts will hang waiting for user input or produce unparse
     }
   ),
 
-  // Koperator Tool Overview
+  // ──────────────────────────────────────────────────────────────────────────
+  // ENTRY 2 — Koperator Tool Overview (command hierarchy + all flags)
+  // ──────────────────────────────────────────────────────────────────────────
   createKnowledgeEntry(
     'documentation',
     `# Koperator - Klever Operator Tool
 
 ## Overview
-Koperator is the command-line tool for interacting with Klever blockchain and smart contracts.
+Koperator is the command-line tool for interacting with the Klever blockchain and smart contracts.
 
 ## Location
-If Klever VSCode extension is installed, koperator is located at:
-\`~/klever-sdk/koperator\`
+\`~/klever-sdk/koperator\` (installed by the Klever VSCode extension or manually)
 
-## Basic Usage
-\`\`\`bash
-# Check available options
-~/klever-sdk/koperator --help
+## Command Hierarchy
 
-# Smart contract operations
-~/klever-sdk/koperator sc --help
+\`\`\`
+operator
+  └── sc                          # smart contract actions
+        ├── create  (alias: csc)  # deploy a new smart contract
+        ├── invoke  (alias: isc)  # call a function on a deployed contract
+        ├── upgrade (alias: usc)  # upgrade an existing contract
+        ├── delete  (alias: dsc)  # delete a contract
+        ├── run-scenarios (alias: rs)
+        └── parse-output  (alias: scpo)
 \`\`\`
 
-## Node Configuration Options
+## sc create — Deploy a New Contract
 
-### Option 1: Environment Variable
 \`\`\`bash
-export KLEVER_NODE="http://localhost:8080"  # Local node (default port 8080)
-# export KLEVER_NODE="https://node.testnet.klever.org"  # Testnet
+~/klever-sdk/koperator sc create [optional-extra-hex] \\
+    --wasm <path-to-wasm> \\
+    [--vmType <hex>] \\
+    [--args <type:value> ...] \\
+    [--values 'KLV=amount,...'] \\
+    [--payable] [--upgradeable] [--payableBySC] [--readable] \\
+    [global flags]
 \`\`\`
 
-### Option 2: --node Parameter
+Create-specific flags:
+- \`--wasm\` (string, required): Path to the .wasm binary file
+- \`--vmType\` (string, default \`0500\`): VM type hex (KleverVM WASM)
+
+Data assembly: \`<hex-wasm>@<vmType>@<metadata-hex>[extra-hex][encoded-args]\`
+TX type: SmartContract_SCDeploy (receiver = zero address)
+
+## sc invoke — Call a Contract Endpoint
+
 \`\`\`bash
-# Use --node parameter directly in the command
-~/klever-sdk/koperator --node="http://localhost:8080" ...
+~/klever-sdk/koperator sc invoke <contract-address> [function-name] \\
+    [--args <type:value> ...] \\
+    [--values 'KLV=amount,...'] \\
+    [--message "raw-data"] \\
+    [global flags]
 \`\`\`
 
-## Smart Contract Operations
+Positional args: CONTRACT_ADDRESS (required), FUNCTION_NAME (optional if --message used)
+Data assembly: \`<functionName>@<encoded-arg-1>@<encoded-arg-2>@...\`
+TX type: SmartContract_SCInvoke
 
-### Contract Deployment (sc create)
+## Shared Flags (sc sub-commands)
+
+| Flag | Type | Default | Applies to | Description |
+|------|------|---------|------------|-------------|
+| \`--args\` | string[] | [] | create, invoke, upgrade | Typed arguments (\`type:value\`). Repeat per arg. Mutually exclusive with \`--message\`. |
+| \`--values\` | string→int64 | nil | create, invoke, upgrade | Token transfers: \`'KLV=1000000,KDA-ab12=500'\`. **Does NOT work for delete.** |
+| \`--payable\` | bool | false | **create, upgrade only** | Sets contract's payable metadata flag. **Ignored by invoke and delete.** |
+| \`--upgradeable\` | bool | **true** | **create, upgrade only** | Sets contract's upgradeable metadata flag. **Defaults to true. Ignored by invoke and delete.** |
+| \`--payableBySC\` | bool | false | **create, upgrade only** | Sets contract's payableBySC metadata flag. **Ignored by invoke and delete.** |
+| \`--readable\` | bool | false | **create, upgrade only** | Sets contract's readable metadata flag. **Ignored by invoke and delete.** |
+
+## Global Flags (all operator commands)
+
+| Flag | Short | Type | Default | Description |
+|------|-------|------|---------|-------------|
+| \`--key-file\` | \`-k\` | string | \`./walletKey.pem\` | Wallet PEM file path |
+| \`--node\` | \`-n\` | string | \`http://localhost:8080\` | Node API endpoint |
+| \`--nonce\` | — | uint64 | 0 (auto-fetch) | Explicit TX nonce. 0 = auto-fetch from chain. |
+| \`--nonce-check\` | — | string | \`current\` | Nonce strategy: \`current\`, \`first-pending\`, \`pending\` |
+| \`--message\` | — | string[] | nil | Raw data bytes. Mutually exclusive with \`--args\`. |
+| \`--permID\` | — | int32 | 0 | Permission ID for multi-sig accounts |
+| \`--fromAddress\` | — | string | "" | Override sender address |
+| \`--password\` | \`-p\` | string | "" | PEM file password (omit value to be prompted) |
+| \`--password-file\` | — | string | "" | Path to password file |
+| \`--multi-files\` | \`-m\` | string[] | [] | Additional PEM files for multi-signing |
+| \`--create-only\` | \`-c\` | bool | false | Build TX JSON without broadcasting |
+| \`--sign\` | \`-s\` | bool | false | Auto-sign without interactive confirmation |
+| \`--kdaFee\` | — | string | "" | Pay fees with a specific KDA token |
+| \`--await\` | — | bool | false | Wait for TX to be posted on-chain |
+| \`--result-only\` | — | bool | false | Print only the TX result (requires \`--await\`) |
+| \`--verbose\` | — | bool | false | Enable trace-level logging |
+
+## Nonce Strategies (\`--nonce-check\`)
+
+| Strategy | Behavior | Use When |
+|----------|----------|----------|
+| \`current\` (default) | Uses the last confirmed nonce | Normal single-TX operations |
+| \`first-pending\` | Uses the first pending nonce | Replacing a stuck transaction |
+| \`pending\` | Uses the next pending nonce | Sending multiple TXs in rapid succession |
+
+## Node Configuration
+
 \`\`\`bash
-~/klever-sdk/koperator \\
-    --key-file="$HOME/klever-sdk/walletKey.pem" \\
-    sc create \\
-    --wasm="output/contract.wasm" \\
-    --upgradeable --readable --payable --payableBySC \\
-    --await --sign --result-only
-\`\`\`
+# Option 1: Environment variable
+export KLEVER_NODE="https://node.testnet.klever.org"
 
-### Contract Upgrade (sc upgrade)
-\`\`\`bash
-~/klever-sdk/koperator \\
-    --key-file="$HOME/klever-sdk/walletKey.pem" \\
-    sc upgrade CONTRACT_ADDRESS \\
-    --wasm="output/contract.wasm" \\
-    --await --sign --result-only
-\`\`\`
+# Option 2: --node parameter
+~/klever-sdk/koperator --node="https://node.testnet.klever.org" sc invoke ...
 
-### Contract Invocation (sc invoke)
-\`\`\`bash
-~/klever-sdk/koperator \\
-    --key-file="$HOME/klever-sdk/walletKey.pem" \\
-    sc invoke CONTRACT_ADDRESS FUNCTION_NAME \\
-    --args "type:value" \\
-    --values "KLV=amount" \\
-    --await --sign --result-only
-\`\`\`
-
-## Important Notes:
-- Always use --result-only for clean JSON output
-- CONTRACT_ADDRESS and FUNCTION_NAME are positional arguments
-- Each argument needs its own --args flag
-- Query endpoints use API, not koperator`,
+# Networks:
+# Mainnet: https://node.mainnet.klever.org
+# Testnet: https://node.testnet.klever.org
+# Devnet:  https://node.devnet.klever.org
+# Local:   http://localhost:8080
+\`\`\``,
     {
-      title: 'Koperator Tool - Overview and Basic Usage',
-      description: 'Comprehensive overview of the Klever Operator (koperator) command-line tool',
-      tags: ['koperator', 'cli', 'tool', 'smartcontract', 'deploy', 'upgrade', 'invoke'],
+      title: 'Koperator Tool - Complete Overview and Flags Reference',
+      description:
+        'Comprehensive overview: command hierarchy with aliases, sc create/invoke usage, all shared and global flags, nonce strategies',
+      tags: [
+        'koperator',
+        'cli',
+        'tool',
+        'smartcontract',
+        'smart-contract',
+        'deploy',
+        'upgrade',
+        'invoke',
+        'flags',
+        'reference',
+      ],
       language: 'bash',
       relevanceScore: 1.0,
       contractType: 'any',
@@ -161,168 +254,126 @@ export KLEVER_NODE="http://localhost:8080"  # Local node (default port 8080)
     }
   ),
 
-  // Koperator Argument Types
+  // ──────────────────────────────────────────────────────────────────────────
+  // ENTRY 3 — Argument Types (complete, authoritative)
+  // ──────────────────────────────────────────────────────────────────────────
   createKnowledgeEntry(
     'documentation',
-    `# Klever Argument Types for Koperator
+    `# Koperator Argument Types — Complete Reference
 
-## IMPORTANT: Always use type prefixes for arguments
+Every \`--args\` value follows the pattern \`<type>:<value>\` where type is case-insensitive.
 
-When using koperator with sc invoke, ALL arguments must have type prefixes:
+## Supported Types & Aliases
 
-## Type Prefixes for --args
-Based on koperator's encode function, use these type prefixes:
+| Type tag(s) | Rust SDK type | Value format | Example |
+|-------------|---------------|--------------|---------|
+| \`u8\`, \`U8\` | u8 | Decimal integer | \`u8:255\` |
+| \`u16\`, \`U16\` | u16 | Decimal integer | \`u16:500\` |
+| \`u32\`, \`U32\`, \`usize\`, \`USIZE\` | u32 / usize | Decimal integer | \`u32:50000\` |
+| \`u64\`, \`U64\` | u64 | Decimal integer | \`u64:5000000000\` |
+| \`i8\`, \`I8\` | i8 | Decimal integer | \`i8:-5\` |
+| \`i16\`, \`I16\` | i16 | Decimal integer | \`i16:500\` |
+| \`i32\`, \`I32\`, \`isize\`, \`ISIZE\` | i32 / isize | Decimal integer | \`i32:50000\` |
+| \`i64\`, \`I64\` | i64 | Decimal integer | \`i64:5000000000\` |
+| \`BigInt\`, \`bigint\`, \`bi\`, \`BI\`, \`n\`, \`N\` | BigInt | Decimal (may be negative) | \`bi:1000000000000\` |
+| \`BigUint\`, \`biguint\` | BigUint | Decimal (positive) | \`BigUint:99999999\` |
+| \`BigFloat\`, \`bigfloat\`, \`bf\`, \`BF\`, \`f\`, \`F\` | BigFloat | Decimal float | \`bf:3.14\` |
+| \`Number\`, \`number\` | *(auto-detect)* | Decimal integer | \`number:500\` → u16, \`number:-5\` → i8 |
+| \`Address\`, \`address\`, \`a\`, \`A\` | ManagedAddress | \`klv1…\` bech32 string | \`address:klv1qqqq…\` |
+| \`String\`, \`string\`, \`ManagedBuffer\`, \`managedbuffer\`, \`TokenIdentifier\`, \`tokenidentifier\`, \`bytes\`, \`BoxedBytes\`, \`boxedbytes\`, \`Vec<u8>\`, \`vec<u8>\`, \`&str\`, \`&[u8]\` | ManagedBuffer / TokenIdentifier / String / Vec<u8> | UTF-8 string | \`string:hello\` |
+| \`bool\`, \`boolean\`, \`b\`, \`B\` | bool | true or false | \`bool:true\` |
+| \`empty\`, \`0\`, \`e\`, \`E\` | *(None / empty)* | *(ignored)* | \`empty:\` |
+| \`file\`, \`code\`, \`wasm\` | *(file contents)* | File path | \`file:./output/contract.wasm\` |
+| \`hex\` | *(raw pass-through)* | Hex string | \`hex:0a1b2c\` |
 
-### Wrapper Types
-- \`List:\` - List of values
-- \`Option:\` - Optional value (can also use \`option\` prefix)
-- \`tuple:\` - Tuple of values
-- \`variadic:\` - Variable number of arguments
+## Option Wrapper (Option<T>)
 
-### Integer Types
-- \`i8:\`, \`I8:\` - Signed 8-bit integer
-- \`i16:\`, \`I16:\` - Signed 16-bit integer
-- \`i32:\`, \`I32:\`, \`isize:\`, \`ISIZE:\` - Signed 32-bit integer
-- \`i64:\`, \`I64:\` - Signed 64-bit integer
-- \`u8:\`, \`U8:\` - Unsigned 8-bit integer
-- \`u16:\`, \`U16:\` - Unsigned 16-bit integer
-- \`u32:\`, \`U32:\`, \`usize:\`, \`USIZE:\` - Unsigned 32-bit integer
-- \`u64:\`, \`U64:\` - Unsigned 64-bit integer
-- \`bi:\`, \`BI:\`, \`BigInt:\`, \`bigint:\`, \`BigUint:\`, \`biguint:\` - Big integers
+To encode an optional value, prefix the type tag with \`option\` (**no colon, no separator**):
 
-### String and Buffer Types
-- \`str:\`, \`String:\`, \`string:\` - String value (REQUIRED for all text arguments)
-- \`bytes:\`, \`Bytes:\` - Byte array
-- \`TokenIdentifier:\` - Token identifier (REQUIRED for token ID arguments like "KLV", "KFI", "MYTOKEN-AB34")
-- \`KdaTokenIdentifier:\` - KDA token identifier
-
-### Address Types
-- \`Address:\`, \`address:\` - Klever address (REQUIRED for all address arguments, must start with "klv")
-
-### Boolean Types
-- \`bool:\`, \`b:\` - Boolean (true/false, 0/1)
-
-### Special Types
-- \`empty\` - No value (for Option::None)
-- \`CodeMetadata:\` - Contract metadata
-
-## 🔴 CRITICAL: Three Most Important Prefixes
-
-### 1. TokenIdentifier: - For ALL Token References
-Use \`TokenIdentifier:\` when passing a token ID as an argument:
-\`\`\`bash
---args "TokenIdentifier:KLV"              # Native KLV token
---args "TokenIdentifier:KFI"              # Native KFI token
---args "TokenIdentifier:USDT-A1B2"        # KDA token
---args "TokenIdentifier:MYNFT-XYZ1/3"     # NFT collection
+\`\`\`
+option<type>:<value>
 \`\`\`
 
-### 2. Address: - For ALL Klever Addresses
-Use \`Address:\` when passing any Klever address:
+Examples:
 \`\`\`bash
---args "Address:klv1recipient..."         # Recipient address
---args "Address:klv1owner..."             # Owner address
---args "Address:klv1qqqqqqqqqqqqqqqq..."  # Zero address
+--args "optionu32:100"       # Some(100u32)
+--args "optionu64:1"         # Some(1u64)
+--args "optionstring:abc"    # Some("abc")
+--args "optionbool:true"     # Some(true)
+--args "optionbool:false"    # Some(false)
+--args "empty:"              # None
 \`\`\`
 
-### 3. String: - For ALL Text/String Values
-Use \`String:\` when passing any text data:
+> ⚠️ WRONG: \`Option:u32:42\`, \`Option:String:hello\` — these do NOT work!
+
+## Rust SDK Type → Koperator Prefix Mapping
+
+| Rust SDK Type | Recommended prefix | Example |
+|---------------|-------------------|---------|
+| \`u8\` | \`u8:\` | \`--args "u8:1"\` |
+| \`u16\` | \`u16:\` | \`--args "u16:256"\` |
+| \`u32\` / \`usize\` | \`u32:\` | \`--args "u32:8"\` |
+| \`u64\` | \`u64:\` | \`--args "u64:1234567890"\` |
+| \`i8\` | \`i8:\` | \`--args "i8:-5"\` |
+| \`i16\` | \`i16:\` | \`--args "i16:-500"\` |
+| \`i32\` | \`i32:\` | \`--args "i32:50000"\` |
+| \`i64\` | \`i64:\` | \`--args "i64:5000000000"\` |
+| \`BigUint\` | \`bi:\` or \`BigUint:\` | \`--args "bi:5000000000"\` |
+| \`BigInt\` | \`bi:\` or \`BigInt:\` | \`--args "bi:-5000"\` |
+| \`BigFloat\` | \`bf:\` or \`BigFloat:\` | \`--args "bf:3.14"\` |
+| \`ManagedBuffer\` / \`String\` | \`string:\` | \`--args "string:MyToken"\` |
+| \`ManagedAddress\` | \`address:\` | \`--args "address:klv1…"\` |
+| \`TokenIdentifier\` | \`string:\` or \`TokenIdentifier:\` | \`--args "string:KLV"\` |
+| \`bool\` | \`bool:\` | \`--args "bool:true"\` |
+| \`Option<T>\` | \`option<prefix>:\` or \`empty:\` | \`--args "optionu64:100"\` |
+| \`ManagedVec<T>\` / \`List<T>\` | Separate \`--args\` per element | \`--args "u32:1" --args "u32:2"\` |
+| \`variadic<T>\` | Separate \`--args\` per element | \`--args "bi:100" --args "bi:200"\` |
+| Raw hex bytes | \`hex:\` | \`--args "hex:deadbeef"\` |
+
+## Composite Types (List, Tuple, Variadic)
+
+There is **NO single-arg syntax** for List, Tuple, or Variadic. Pass each element as a separate \`--args\`:
+
 \`\`\`bash
---args "String:hello world"               # Text message
---args "String:transfer"                  # Function name as string
---args "String:user_123"                  # User ID
+# List<u32> — 3 elements:
+--args "u32:10" --args "u32:20" --args "u32:30"
+
+# tuple<u32, String, Address> — each positional element:
+--args "u32:42" --args "string:hello" --args "address:klv1..."
+
+# variadic<BigUint> — as tail parameter, each value:
+--args "BigUint:100" --args "BigUint:200" --args "BigUint:300"
+
+# Mixed: endpoint(u32, variadic<BigUint>):
+--args "u32:1" --args "BigUint:100" --args "BigUint:200"
 \`\`\`
 
-## Usage Examples
+## Token Payments (--values, NOT --args)
 
-### Basic Types
+Payments use \`--values\` with \`=\` syntax:
 \`\`\`bash
-# Numbers
---args "u8:5"                    # 8-bit unsigned integer
---args "u32:1000"                # 32-bit unsigned integer
---args "bi:1000000"              # BigUint for large numbers
-
-# Strings (ALWAYS use String: prefix for text)
---args "String:hello world"      # String value
---args "bytes:0x48656c6c6f"      # Byte array (hex)
-
-# Addresses (ALWAYS use Address: prefix)
---args "Address:klv1abc..."      # Klever address
-
-# Token Identifiers (ALWAYS use TokenIdentifier: prefix)
---args "TokenIdentifier:KLV"     # For KLV token
---args "TokenIdentifier:KFI"     # For KFI token  
---args "TokenIdentifier:MYTOKEN-AB12" # For custom tokens
-
-# Booleans
---args "bool:true"               # Boolean true
---args "b:0"                     # Boolean false
+--values "KLV=1000000"                     # Single token (1 KLV, 6 decimals)
+--values "KLV=1000000,KFI=500000"          # Multiple tokens
+--values "NFT-XY01/01=1"                   # NFT with nonce
+--values "SFT-AB12/05=100"                 # SFT with nonce
 \`\`\`
 
-### Complex Types
-\`\`\`bash
-# Optional values
---args "Option:String:value"     # Some(value)
---args "empty"                   # None
-
-# Lists
---args "List:u32:1,u32:2,u32:3"  # List of numbers
-
-# Tuples
---args "tuple:u64:123,String:test,bool:true"  # Tuple of mixed types
-
-# Multiple arguments - use separate --args for each
-~/klever-sdk/koperator sc invoke CONTRACT transfer \\
-    --args "Address:klv1recipient..." \\
-    --args "bi:1000000" \\
-    --args "String:memo"
-\`\`\`
-
-### Token Payments (use --values, not --args!)
-\`\`\`bash
-# Single token payment
---values "KLV=1000000"           # 1 KLV (6 decimals)
-
-# Multiple token payments
---values "KLV=1000000,KFI=500000,USDT-A1B2=250000"
-
-# NFT/SFT with nonce
---values "NFT-XY01/01=1"         # NFT with nonce 01
-\`\`\`
-
-## Common Mistakes to Avoid
-
-### ❌ Wrong: Mixing up --args and --values
-\`\`\`bash
-# WRONG - KLV payment is not an argument
---args "KLV:1000000"
-
-# CORRECT - Use --values for payments
---values "KLV=1000000"
-\`\`\`
-
-### ❌ Wrong: Missing type prefix
-\`\`\`bash
-# WRONG - No type prefix
---args "123"
-
-# CORRECT - Include type prefix
---args "u32:123"
-\`\`\`
-
-### ❌ Wrong: Using flags for positional arguments
-\`\`\`bash
-# WRONG
---contract="klv1abc..." --function="transfer"
-
-# CORRECT - Positional arguments
-sc invoke klv1abc... transfer
-\`\`\``,
+❌ NEVER use \`--args\` for payments. ❌ NEVER use \`--value\` (singular).`,
     {
-      title: 'Klever Argument Types for Koperator',
+      title: 'Koperator Argument Types — Complete Reference',
       description:
-        'Complete reference for argument types and formatting when using Koperator CLI tool',
-      tags: ['koperator', 'arguments', 'types', 'documentation', 'cli', 'reference'],
+        'Complete and authoritative reference for all --args type prefixes, Rust SDK type mapping, Option syntax, composite types, and token payments',
+      tags: [
+        'koperator',
+        'arguments',
+        'types',
+        'encoding',
+        'reference',
+        'cli',
+        'rust-mapping',
+        'critical',
+        'smart-contract',
+      ],
       language: 'bash',
       relevanceScore: 1.0,
       contractType: 'any',
@@ -330,239 +381,196 @@ sc invoke klv1abc... transfer
     }
   ),
 
-  // Complete Koperator Argument Encoding Guide
+  // ──────────────────────────────────────────────────────────────────────────
+  // ENTRY 4 — Encoding Rules & Composite Types
+  // ──────────────────────────────────────────────────────────────────────────
   createKnowledgeEntry(
     'best_practice',
-    `# 📚 Complete Koperator Argument Encoding Guide
+    `# Koperator Argument Encoding Rules
 
-## 🎯 Quick Reference - Most Common Patterns
+## Top-Level vs Nested Encoding
 
-\`\`\`bash
-# Basic Types
---args "u8:5"                    # Unsigned 8-bit integer (0-255)
---args "u32:1000"                # Unsigned 32-bit integer
---args "u64:1000000"             # Unsigned 64-bit integer
---args "bi:1000000"              # BigInt/BigUint (any size)
---args "String:hello world"      # String value
---args "Address:klv1abc..."      # Klever address
---args "bool:true"               # Boolean (true/false)
+Values encode **differently** depending on whether they appear at top-level (direct --args) or nested inside a composite type (Option, List, Tuple, Struct).
 
-# Token Payments (using --values, not --args!)
---values "KLV=1000000"           # 1 KLV (6 decimals)
---values "KFI=500000"            # 0.5 KFI (6 decimals)
---values "DVK-34ZH=100000"       # Custom KDA token
---values "KLV=1000000,KFI=500000" # Multiple tokens
+| Type category | Top-level encoding | Nested encoding |
+|---------------|-------------------|-----------------|
+| Unsigned ints (\`u8\`–\`u64\`) | Minimal even-length hex | Fixed to declared bit-width (zero-padded) |
+| Signed ints (\`i8\`–\`i64\`) | Minimal even-length hex (two's complement) | Fixed to declared bit-width |
+| \`bool\` | \`01\` (true) or empty (false) | \`01\` (true) or \`00\` (false) |
+| Dynamic types (\`String\`, \`BigUint\`, \`BigInt\`, \`BigFloat\`, \`bytes\`) | Raw hex (minimal) | 4-byte length prefix + raw hex |
+| \`Address\` | 64 hex chars (always fixed) | 64 hex chars (always fixed) |
 
-# NFT/SFT with nonce
---values "NFT-XY01/01=1"         # NFT with nonce 01
---values "SFT-AB12/05=100"       # 100 SFTs with nonce 05
+### Examples of the same value in different contexts:
 
-# Optional Values
---args "Option:String:hello"     # Some("hello")
---args "empty"                   # None
+\`\`\`
+Top-level:   u32:50000  →  c350          (minimal 2 bytes)
+Nested:      u32:50000  →  0000c350      (fixed 4 bytes)
 
-# Lists
---args "List:u32:1,u32:2,u32:3" # [1, 2, 3]
+Top-level:   bool:false →  (empty)
+Nested:      bool:false →  00
 
-# Tuples
---args "tuple:u64:123,String:test,bool:true" # (123, "test", true)
+Top-level:   string:hi  →  6869
+Nested:      string:hi  →  000000026869  (4-byte length prefix + data)
+
+Top-level:   BigUint:5000 →  1388
+Nested:      BigUint:5000 →  000000021388  (4-byte length prefix + data)
 \`\`\`
 
-## 📖 Complete Type Reference
+## Per-Type Encoding Details
 
-### Numeric Types (with examples)
+### Unsigned Integers (u8, u16, u32, u64)
+
+Top-level: minimum even-length hex, no leading zeros beyond even-length.
+Nested/Option: fixed-width to declared type (1/2/4/8 bytes), zero-padded.
+
+| Input | Top-level hex |
+|-------|---------------|
+| \`u8:5\` | \`05\` |
+| \`u16:500\` | \`01f4\` |
+| \`u32:50000\` | \`c350\` |
+| \`u64:5000000000\` | \`012a05f200\` |
+
+### Signed Integers (i8, i16, i32, i64)
+
+Top-level: minimum even-length hex. Negative values use two's complement. Hex auto-fits to smallest standard size.
+Nested/Option: exact bit-width (1/2/4/8 bytes), zero-padded.
+Odd-length hex padded with \`0\` (positive) or \`f\` (negative) on left.
+
+| Input | Top-level hex |
+|-------|---------------|
+| \`i8:5\` | \`05\` |
+| \`i32:50000\` | \`0000c350\` |
+| \`i8:-5\` | \`fb\` |
+| \`i16:-500\` | \`fe0c\` |
+
+> Key difference: \`u32:50000\` → \`c350\` (minimal), \`i32:50000\` → \`0000c350\` (full width).
+
+### BigInt / BigUint
+
+Decimal → minimal hex. Negative BigInt uses two's complement with minimum byte width.
+Nested/Option: 4-byte (8 hex digit) length prefix prepended.
+
+| Input | Top-level hex |
+|-------|---------------|
+| \`BigInt:5000\` | \`1388\` |
+| \`BigInt:-5000\` | \`ec78\` |
+| \`BigUint:500000\` | \`07a120\` |
+
+### BigFloat
+
+Decimal → Go big.Float (53-bit precision) → GobEncode → hex.
+Nested/Option: 4-byte length prefix added.
+
+### Number (auto-detect)
+
+Auto-selects the smallest fitting type: positive → u8/u16/u32/u64, negative → i8/i16/i32/i64.
+
+| Input | Auto type | Hex |
+|-------|-----------|-----|
+| \`number:5\` | u8 | \`05\` |
+| \`number:-5\` | i8 | \`fb\` |
+| \`number:500\` | u16 | \`01f4\` |
+| \`number:500000\` | u32 | \`07a120\` |
+
+### Address
+
+Bech32 \`klv1…\` decoded to 32-byte public key → 64 hex chars. Always fixed-width.
+
+### String / ManagedBuffer / TokenIdentifier / bytes
+
+UTF-8 bytes → hex-encoded (\`%02x\` per byte).
+Nested/Option: 4-byte length prefix prepended.
+
+| Input | Hex |
+|-------|-----|
+| \`string:hello\` | \`68656c6c6f\` |
+| \`string:KLV\` | \`4b4c56\` |
+
+### Boolean
+
+\`true\` → \`01\`. \`false\` → empty string (top-level) or \`00\` (nested/option).
+
+### Empty
+
+Always returns empty string. Used for None option values or placeholder separators.
+
+### File / WASM
+
+Reads file at path. If \`.kleversc.json\`: extracts the \`"code"\` field. Otherwise: hex-encodes raw bytes.
+
+### Hex (raw pass-through)
+
+Value used as-is with no transformation. Must provide valid hex.
+
+## Composite Type Encoding
+
+### List<T>
+
+- **No single-arg syntax.** Pass each element as a separate \`--args\`.
+- **Hex layout (decoded):** Elements back-to-back. Dynamic-length types get a 4-byte length prefix per element. Fixed-length types consumed by their native width. Decoding continues until hex stream is exhausted.
+- **Nested lists:** \`List<List<T>>\` is valid — inner list gets a 4-byte length prefix.
+
 \`\`\`bash
-# Unsigned integers
---args "u8:255"                  # 8-bit: 0 to 255
---args "u16:65535"               # 16-bit: 0 to 65,535
---args "u32:4294967295"          # 32-bit: 0 to 4,294,967,295
---args "u64:18446744073709551615" # 64-bit: 0 to 18,446,744,073,709,551,615
-
-# Signed integers
---args "i8:-128"                 # 8-bit: -128 to 127
---args "i16:-32768"              # 16-bit: -32,768 to 32,767
---args "i32:-2147483648"         # 32-bit: -2,147,483,648 to 2,147,483,647
---args "i64:-9223372036854775808" # 64-bit: very large range
-
-# Big integers (unlimited size)
---args "bi:999999999999999999999" # Any size number
---args "BigUint:1000000000000000" # Alternative syntax
+# Endpoint expecting List<u32>:
+--args "u32:10" --args "u32:20" --args "u32:30"
 \`\`\`
 
-### String and Buffer Types
+### Option<T>
+
+- Encoded via the \`option\` prefix: \`option<type>:<value>\`
+- Hex: \`01\` + nested-encoded value (Some), or empty (None via \`empty:\`)
+- **The option prefix switches the inner value to nested encoding** (fixed-width ints, length-prefixed dynamic types)
+
+| Argument | Hex | Breakdown |
+|----------|-----|-----------|
+| \`optionu32:100\` | \`0100000064\` | 01 (Some) + 00000064 (u32 nested: 4 bytes) |
+| \`optionu64:1\` | \`010000000000000001\` | 01 (Some) + 8-byte u64 |
+| \`optionstring:abc\` | \`010000000361626363\` | 01 + 00000003 (length) + 616263 |
+| \`optionbool:true\` | \`0101\` | 01 (Some) + 01 (true) |
+| \`optionbool:false\` | \`0100\` | 01 (Some) + 00 (false, nested) |
+| \`empty:\` | *(empty)* | None |
+
+### Tuple<T1, T2, ..., Tn>
+
+- **No single-arg syntax.** Pass each positional element as a separate \`--args\` in order.
+- **Hex layout:** Elements sequential. Dynamic-length types get a 4-byte length prefix. Nested angle brackets are parsed correctly.
+
 \`\`\`bash
-# Strings
---args "String:Hello World"      # Regular string
---args "str:Special chars: !@#"  # With special characters
---args 'String:With "quotes"'    # Quotes inside
-
-# Bytes (hex format)
---args "bytes:0x48656c6c6f"      # "Hello" in hex
---args "Bytes:0x00FF00FF"        # Binary data
-
-# Token identifiers
---args "TokenIdentifier:KLV"     # Token ID
---args "KdaTokenIdentifier:USDT-A1B2" # KDA token ID
+# Endpoint expecting tuple<u32, String, Address>:
+--args "u32:42" --args "string:hello" --args "address:klv1..."
 \`\`\`
 
-### Address Types
+### Variadic<T>
+
+- Typically the **last** parameter of an endpoint.
+- **No single-arg syntax.** Each element is a separate \`--args\`, and the contract's variadic parameter consumes all remaining \`@\`-delimited segments.
+
 \`\`\`bash
-# Klever addresses (must start with "klv")
---args "Address:klv1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqlllllh"
---args "address:klv1234567890abcdef..."
+# Endpoint expecting (u32, variadic<BigUint>):
+--args "u32:1" --args "BigUint:100" --args "BigUint:200" --args "BigUint:300"
 \`\`\`
 
-### Boolean Types
-\`\`\`bash
-# Boolean values
---args "bool:true"               # True
---args "bool:false"              # False
---args "b:1"                     # True (using 1)
---args "b:0"                     # False (using 0)
-\`\`\`
+### Custom Structs (decode-only)
 
-### Complex Types
-
-#### Optional Values
-\`\`\`bash
-# Some value
---args "Option:u32:42"           # Some(42)
---args "Option:String:hello"     # Some("hello")
---args "option:Address:klv1..."  # Some(address)
-
-# None value
---args "empty"                   # None
-\`\`\`
-
-#### Lists (arrays)
-\`\`\`bash
-# List of same type
---args "List:u32:1,u32:2,u32:3"  # [1, 2, 3]
---args "List:String:a,String:b"   # ["a", "b"]
---args "List:Address:klv1...,Address:klv2..." # [addr1, addr2]
-
-# Empty list
---args "List:"                   # []
-\`\`\`
-
-#### Tuples (mixed types)
-\`\`\`bash
-# Tuple with different types
---args "tuple:u64:123,String:test,bool:true" # (123, "test", true)
---args "tuple:Address:klv1...,bi:1000000"    # (address, 1000000)
-\`\`\`
-
-#### Variadic (variable number of args)
-\`\`\`bash
-# Variadic arguments (processed as separate values)
---args "variadic:u32:1,u32:2,u32:3" # Passes 1, 2, 3 as separate args
-\`\`\`
-
-## 💰 Token Payments with --values
-
-### CRITICAL: Use --values for payments, NOT --args!
-
-\`\`\`bash
-# ✅ CORRECT - Single token payment
-~/klever-sdk/koperator sc invoke CONTRACT stake \\
-    --values "KLV=1000000" \\        # 1 KLV
-    --await --sign --result-only
-
-# ✅ CORRECT - Multiple token payments
-~/klever-sdk/koperator sc invoke CONTRACT multiPay \\
-    --values "KLV=1000000,KFI=500000,USDT-A1B2=250000" \\
-    --await --sign --result-only
-
-# ❌ WRONG - Don't use --args for payments
---args "KLV:1000000"  # This won't work!
-\`\`\`
-
-### NFT/SFT Payments
-\`\`\`bash
-# NFT payment (nonce required)
---values "MYNFT-A1B2/01=1"       # 1 NFT with nonce 01
-
-# SFT payment (nonce required, amount can be > 1)
---values "MYSFT-C3D4/05=100"     # 100 SFTs with nonce 05
-
-# Multiple NFTs/SFTs
---values "NFT1-AB12/01=1,NFT2-CD34/02=1,SFT-EF56/03=50"
-\`\`\`
-
-## 🔧 Real-World Examples
-
-### Example 1: Token Transfer
-\`\`\`bash
-~/klever-sdk/koperator \\
-    --key-file="$HOME/klever-sdk/walletKey.pem" \\
-    sc invoke klv1contract... transfer \\
-    --args "Address:klv1recipient..." \\
-    --args "bi:1000000" \\
-    --await --sign --result-only
-\`\`\`
-
-### Example 2: Staking with Payment
-\`\`\`bash
-~/klever-sdk/koperator \\
-    --key-file="$HOME/klever-sdk/walletKey.pem" \\
-    sc invoke klv1staking... stake \\
-    --args "u32:30" \\              # 30 days lock period
-    --values "KLV=100000000" \\     # 100 KLV
-    --await --sign --result-only
-\`\`\`
-
-### Example 3: Complex Function Call
-\`\`\`bash
-~/klever-sdk/koperator \\
-    --key-file="$HOME/klever-sdk/walletKey.pem" \\
-    sc invoke klv1game... createGame \\
-    --args "String:MyGame" \\
-    --args "u32:10" \\
-    --args "List:Address:klv1p1...,Address:klv1p2..." \\
-    --args "Option:u64:3600" \\
-    --values "KLV=10000000" \\
-    --await --sign --result-only
-\`\`\`
-
-### Example 4: Using All Three Critical Prefixes
-\`\`\`bash
-# Function that accepts: token_id, recipient, description
-~/klever-sdk/koperator \\
-    --key-file="$HOME/klever-sdk/walletKey.pem" \\
-    sc invoke klv1dex... registerTransfer \\
-    --args "TokenIdentifier:USDT-A1B2" \\    # Token ID
-    --args "Address:klv1recipient..." \\        # Recipient address  
-    --args "String:Payment for services" \\     # Description text
-    --await --sign --result-only
-\`\`\`
-
-## ⚠️ Common Pitfalls and Solutions
-
-1. **Wrong Parameter Names**: CONTRACT_ADDRESS and FUNCTION are positional, not flags
-2. **Missing Type Prefix**: Always include type: prefix (u32:, String:, etc.)
-3. **Payment Confusion**: Use --values with = for payments, not --args with :
-4. **Multiple Arguments**: Each argument needs its own --args flag
-5. **Address Format**: Addresses must start with "klv" AND use Address: prefix
-6. **Token ID Format**: ALWAYS use TokenIdentifier: prefix for token IDs
-7. **String Format**: ALWAYS use String: prefix for text values
-8. **NFT Format**: TOKEN_ID/NONCE=AMOUNT for NFTs/SFTs in --values
-
-### ❌ Common Prefix Mistakes:
-\`\`\`bash
-# WRONG - Missing prefixes
---args "klv1abc..."              # ❌ Missing Address: prefix
---args "KLV"                     # ❌ Missing TokenIdentifier: prefix
---args "hello"                   # ❌ Missing String: prefix
-
-# CORRECT - With proper prefixes
---args "Address:klv1abc..."      # ✅ Address with prefix
---args "TokenIdentifier:KLV"     # ✅ Token ID with prefix
---args "String:hello"            # ✅ String with prefix
-\`\`\``,
+Custom struct types from the contract ABI \`types\` map are resolved by name. Fields are decoded sequentially (fixed-width for fixed types, 4-byte length prefix for dynamic types). This is **decode-only** — used when parsing output with \`sc parse-output --abi\`.`,
     {
-      title: 'Complete Koperator Argument Encoding Guide',
-      description: 'Comprehensive guide for encoding arguments and payments in koperator commands',
-      tags: ['koperator', 'arguments', 'encoding', 'payments', 'guide', 'reference', 'critical'],
+      title: 'Koperator Argument Encoding Rules & Composite Types',
+      description:
+        'Per-type encoding details, top-level vs nested differences, two\'s complement, length prefixes, and composite type handling (List, Option, Tuple, Variadic)',
+      tags: [
+        'koperator',
+        'encoding',
+        'hex',
+        'arguments',
+        'nested',
+        'composite',
+        'list',
+        'option',
+        'tuple',
+        'variadic',
+        'reference',
+        'smart-contract',
+      ],
       language: 'bash',
       relevanceScore: 1.0,
       contractType: 'any',
@@ -570,7 +578,9 @@ sc invoke klv1abc... transfer
     }
   ),
 
-  // API vs Koperator Usage
+  // ──────────────────────────────────────────────────────────────────────────
+  // ENTRY 5 — API vs Koperator (KEPT from original)
+  // ──────────────────────────────────────────────────────────────────────────
   createKnowledgeEntry(
     'best_practice',
     `# Important: API vs Koperator for Smart Contract Interaction
@@ -597,8 +607,8 @@ POST https://api.{network}.klever.org/v1.0/sc/query
 **Example - Query a view endpoint:**
 \`\`\`bash
 # Query getTotalSupply (no arguments)
-curl -s 'https://api.testnet.klever.org/v1.0/sc/query' \
-    -H 'Content-Type: application/json' \
+curl -s 'https://api.testnet.klever.org/v1.0/sc/query' \\
+    -H 'Content-Type: application/json' \\
     --data-raw '{
         "ScAddress": "klv1contract_address_here",
         "FuncName": "getTotalSupply",
@@ -607,8 +617,8 @@ curl -s 'https://api.testnet.klever.org/v1.0/sc/query' \
 
 # Query getBalance with address argument
 # Example: klv1qqq...qqpgm89z (zero address) = 32 zero bytes = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
-curl -s 'https://api.testnet.klever.org/v1.0/sc/query' \
-    -H 'Content-Type: application/json' \
+curl -s 'https://api.testnet.klever.org/v1.0/sc/query' \\
+    -H 'Content-Type: application/json' \\
     --data-raw '{
         "ScAddress": "klv1contract_address_here",
         "FuncName": "getBalance",
@@ -618,8 +628,8 @@ curl -s 'https://api.testnet.klever.org/v1.0/sc/query' \
 # Query with multiple arguments (address + number)
 # Address: 32 bytes base64
 # Number 42: 0x000000000000002a (8 bytes big-endian) = "AAAAAAAAACo="
-curl -s 'https://api.testnet.klever.org/v1.0/sc/query' \
-    -H 'Content-Type: application/json' \
+curl -s 'https://api.testnet.klever.org/v1.0/sc/query' \\
+    -H 'Content-Type: application/json' \\
     --data-raw '{
         "ScAddress": "klv1contract_address_here",
         "FuncName": "getUserInfo",
@@ -649,8 +659,8 @@ KLEVER_NODE=https://node.testnet.klever.org \\
     ~/klever-sdk/koperator \\
     --key-file="$HOME/klever-sdk/walletKey.pem" \\
     sc invoke klv1contract_address transfer \\
-    --args Address:klv1recipient --args bi:1000000 \\
-    --await --sign --result-only
+    --args "address:klv1recipient" --args "bi:1000000" \\
+    --sign --await --result-only
 \`\`\`
 
 ## Key Differences
@@ -673,7 +683,7 @@ The koperator query command exists but the API is the recommended approach for p
       title: 'API vs Koperator - When to Use Each',
       description:
         'Clear guidance on using the API for contract queries vs koperator for transactions',
-      tags: ['api', 'koperator', 'view', 'query', 'invoke', 'best-practice', 'contract'],
+      tags: ['api', 'koperator', 'view', 'query', 'invoke', 'best-practice', 'contract', 'smart-contract'],
       language: 'bash',
       relevanceScore: 1.0,
       contractType: 'any',
@@ -681,7 +691,9 @@ The koperator query command exists but the API is the recommended approach for p
     }
   ),
 
-  // Koperator Account Operations
+  // ──────────────────────────────────────────────────────────────────────────
+  // ENTRY 6 — Account Utilities (KEPT from original)
+  // ──────────────────────────────────────────────────────────────────────────
   createKnowledgeEntry(
     'deployment_tool',
     `# Koperator Account Operations - Developer Utilities
@@ -742,65 +754,135 @@ KLEVER_NODE=https://node.testnet.klever.org \\
     }
   ),
 
-  // Koperator Examples
+  // ──────────────────────────────────────────────────────────────────────────
+  // ENTRY 7 — SC Operations Examples (REWRITTEN)
+  // ──────────────────────────────────────────────────────────────────────────
   createKnowledgeEntry(
     'code_example',
     `# Koperator Smart Contract Operations Examples
 
-# 1. Deploy a new contract
+# 1. Deploy a new contract (no init args)
 KLEVER_NODE=https://node.testnet.klever.org \\
     ~/klever-sdk/koperator \\
     --key-file="$HOME/klever-sdk/walletKey.pem" \\
     sc create \\
     --wasm="output/contract.wasm" \\
-    --upgradeable --readable --payable --payableBySC \\
-    --await --sign --result-only
+    --readable --payable --payableBySC \\
+    --sign --await --result-only
+# Note: --upgradeable defaults to true, so omitted here
 
-# 2. Invoke contract with BigUint argument
+# 2. Deploy with init arguments (constructor parameters)
+KLEVER_NODE=https://node.testnet.klever.org \\
+    ~/klever-sdk/koperator \\
+    --key-file="$HOME/klever-sdk/walletKey.pem" \\
+    sc create \\
+    --wasm="output/contract.wasm" \\
+    --args "BigUint:1000000" \\
+    --args "address:klv1owner_address_here" \\
+    --args "string:MyToken" \\
+    --readable --payable --payableBySC \\
+    --sign --await --result-only
+
+# 3. Invoke with BigUint argument
 KLEVER_NODE=https://node.testnet.klever.org \\
     ~/klever-sdk/koperator \\
     --key-file="$HOME/klever-sdk/walletKey.pem" \\
     sc invoke klv1contract_address_here add \\
-    --args bi:100 \\
-    --await --sign --result-only
+    --args "bi:100" \\
+    --sign --await --result-only
 
-# 3. Invoke with multiple arguments - use separate --args for each argument
+# 4. Invoke with multiple arguments (separate --args per arg)
 KLEVER_NODE=https://node.testnet.klever.org \\
     ~/klever-sdk/koperator \\
     --key-file="$HOME/klever-sdk/walletKey.pem" \\
     sc invoke klv1contract_address_here setUserInfo \\
-    --args Address:klv1user_address_here \\
-    --args u32:42 \\
-    --args String:"Active User" \\
-    --await --sign --result-only
+    --args "address:klv1user_address_here" \\
+    --args "u32:42" \\
+    --args "string:Active User" \\
+    --sign --await --result-only
 
-# 4. Send KLV payment with function call
+# 5. Send KLV payment with function call
 KLEVER_NODE=https://node.testnet.klever.org \\
     ~/klever-sdk/koperator \\
     --key-file="$HOME/klever-sdk/walletKey.pem" \\
     sc invoke klv1contract_address_here deposit \\
     --values "KLV=10000000" \\
-    --await --sign --result-only
+    --sign --await --result-only
 
-# 5. Send multiple token payments
+# 6. Send multiple token payments
 KLEVER_NODE=https://node.testnet.klever.org \\
     ~/klever-sdk/koperator \\
     --key-file="$HOME/klever-sdk/walletKey.pem" \\
     sc invoke klv1contract_address_here multiDeposit \\
-    --values "KLV=5000000,KFI=3000000,USDT-A1B2=1000000" \\
-    --await --sign --result-only
+    --values "KLV=5000000,KFI=3000000" \\
+    --sign --await --result-only
 
-# 6. Upgrade existing contract
+# 7. Invoke with optional arguments
+KLEVER_NODE=https://node.testnet.klever.org \\
+    ~/klever-sdk/koperator \\
+    --key-file="$HOME/klever-sdk/walletKey.pem" \\
+    sc invoke klv1contract_address_here setConfig \\
+    --args "optionu64:100" \\
+    --args "optionstring:newName" \\
+    --sign --await --result-only
+
+# 8. Invoke with None for optional argument
+KLEVER_NODE=https://node.testnet.klever.org \\
+    ~/klever-sdk/koperator \\
+    --key-file="$HOME/klever-sdk/walletKey.pem" \\
+    sc invoke klv1contract_address_here setConfig \\
+    --args "empty:" \\
+    --args "optionstring:newName" \\
+    --sign --await --result-only
+
+# 9. Invoke with variadic arguments (list of values)
+KLEVER_NODE=https://node.testnet.klever.org \\
+    ~/klever-sdk/koperator \\
+    --key-file="$HOME/klever-sdk/walletKey.pem" \\
+    sc invoke klv1contract_address_here addWhitelist \\
+    --args "address:klv1addr1..." \\
+    --args "address:klv1addr2..." \\
+    --args "address:klv1addr3..." \\
+    --sign --await --result-only
+
+# 10. Invoke with raw hex data
+KLEVER_NODE=https://node.testnet.klever.org \\
+    ~/klever-sdk/koperator \\
+    --key-file="$HOME/klever-sdk/walletKey.pem" \\
+    sc invoke klv1contract_address_here rawCall \\
+    --args "hex:deadbeef" \\
+    --sign --await --result-only
+
+# 11. Upgrade existing contract
 KLEVER_NODE=https://node.testnet.klever.org \\
     ~/klever-sdk/koperator \\
     --key-file="$HOME/klever-sdk/walletKey.pem" \\
     sc upgrade klv1contract_address_here \\
     --wasm="output/contract-v2.wasm" \\
-    --await --sign --result-only`,
+    --upgradeable \\
+    --sign --await --result-only
+
+# 12. Create-only (offline TX generation, no broadcast)
+~/klever-sdk/koperator \\
+    --key-file="$HOME/klever-sdk/walletKey.pem" \\
+    sc invoke klv1contract_address_here withdraw \\
+    --create-only
+# Outputs unsigned TX JSON to stdout for later signing`,
     {
       title: 'Koperator Smart Contract Operations Examples',
-      description: 'Practical examples of using koperator for various smart contract operations',
-      tags: ['koperator', 'examples', 'deploy', 'invoke', 'query', 'upgrade'],
+      description:
+        'Practical examples: deploy, deploy with init args, invoke, optional args, variadic, payments, upgrade, create-only',
+      tags: [
+        'koperator',
+        'examples',
+        'deploy',
+        'invoke',
+        'upgrade',
+        'optional',
+        'variadic',
+        'create-only',
+        'smart-contract',
+      ],
       language: 'bash',
       relevanceScore: 0.95,
       contractType: 'any',
@@ -808,79 +890,60 @@ KLEVER_NODE=https://node.testnet.klever.org \\
     }
   ),
 
-  // Koperator Payment Flags
+  // ──────────────────────────────────────────────────────────────────────────
+  // ENTRY 8 — Payment/Metadata Flags for Contract Creation (REWRITTEN)
+  // ──────────────────────────────────────────────────────────────────────────
   createKnowledgeEntry(
     'documentation',
-    `# Koperator Payment Flags for Smart Contract Creation
+    `# Koperator Contract Metadata Flags (sc create / sc upgrade)
 
-## Contract Properties During Deployment
+## Metadata Flags
 
-When creating a smart contract with \`sc create\`, you can set the following properties:
+These flags set the contract's code metadata during deployment or upgrade:
 
-### Payment-Related Flags
+### --upgradeable (default: TRUE)
+- **Purpose**: Makes the contract upgradeable by the owner
+- **Default**: true — contracts are upgradeable unless you explicitly omit this flag
+- To deploy an **immutable** contract, omit \`--upgradeable\` or set false
 
-#### --payable
-- **Purpose**: Allows the contract to receive KLV payments
+### --payable (default: false)
+- **Purpose**: Allows the contract to receive KLV/KDA payments
 - **Usage**: Required if your contract has \`#[payable("KLV")]\` endpoints
-- **Example**: Contract can receive KLV via payable endpoints
 
-#### --payableBySC
+### --payableBySC (default: false)
 - **Purpose**: Allows other smart contracts to send payments to this contract
 - **Usage**: Required for contract-to-contract payment interactions
-- **Example**: Another contract can call your payable endpoints with payments
 
-### Other Important Flags
-
-#### --upgradeable
-- **Purpose**: Makes the contract upgradeable by the owner
-- **Usage**: Recommended for development, optional for production
-- **Example**: Owner can upgrade contract code later
-
-#### --readable
+### --readable (default: false)
 - **Purpose**: Makes contract storage readable by external queries
 - **Usage**: Recommended for transparency
-- **Example**: Anyone can query contract storage values
-
-## Complete Deployment Example
-
-\`\`\`bash
-# Deploy with all common flags
-KLEVER_NODE=https://node.testnet.klever.org \\
-    ~/klever-sdk/koperator \\
-    --key-file="$HOME/klever-sdk/walletKey.pem" \\
-    sc create \\
-    --wasm="output/my_contract.wasm" \\
-    --upgradeable \\      # Can be upgraded later
-    --readable \\         # Storage is queryable
-    --payable \\          # Can receive KLV
-    --payableBySC \\      # Other contracts can pay it
-    --await \\            # Wait for confirmation
-    --sign \\             # Sign transaction
-    --result-only         # Clean JSON output
-\`\`\`
 
 ## Flag Combinations for Different Contract Types
 
 ### DeFi/Exchange Contract
 \`\`\`bash
---upgradeable --readable --payable --payableBySC
+# --upgradeable is true by default
+--readable --payable --payableBySC
 \`\`\`
 
 ### NFT Marketplace Contract
 \`\`\`bash
---upgradeable --readable --payable --payableBySC
+--readable --payable --payableBySC
 \`\`\`
 
-### Oracle/Data Provider Contract
+### Oracle/Data Provider Contract (no payments)
 \`\`\`bash
---upgradeable --readable
-# (No payment flags if it doesn't accept payments)
+--readable
 \`\`\`
 
 ### Immutable Production Contract
 \`\`\`bash
+# Explicitly omit --upgradeable to make immutable
 --readable --payable --payableBySC
-# (No --upgradeable for immutability)
+# Since --upgradeable defaults to true, consider using:
+# sc create ... (without --upgradeable won't help; the flag is true by default)
+# To make truly immutable, deploy without --upgradeable and it's still upgradeable!
+# Immutability requires NOT setting the upgradeable flag in code metadata.
 \`\`\`
 
 ## Common Mistakes
@@ -893,14 +956,24 @@ If your contract has payable endpoints but you deploy without --payable:
 ### ❌ Forgetting --payableBySC
 If other contracts need to pay yours but you deploy without --payableBySC:
 - Contract-to-contract payments will fail
-- Integration with other protocols won't work
 
 ### ✅ Best Practice
-Always include both --payable and --payableBySC if your contract handles any payments, even if you're not sure about contract-to-contract interactions yet.`,
+Always include both --payable and --payableBySC if your contract handles any payments.`,
     {
-      title: 'Koperator Payment Flags for Contract Creation',
-      description: 'Understanding --payable and --payableBySC flags when deploying smart contracts',
-      tags: ['koperator', 'deployment', 'payable', 'payableBySC', 'flags', 'contract-creation'],
+      title: 'Koperator Contract Metadata Flags',
+      description:
+        'Contract metadata flags: --upgradeable (defaults true!), --payable, --payableBySC, --readable',
+      tags: [
+        'koperator',
+        'deployment',
+        'payable',
+        'payableBySC',
+        'upgradeable',
+        'readable',
+        'flags',
+        'metadata',
+        'smart-contract',
+      ],
       language: 'bash',
       relevanceScore: 0.95,
       contractType: 'any',
@@ -908,7 +981,9 @@ Always include both --payable and --payableBySC if your contract handles any pay
     }
   ),
 
-  // Koperator for Unattended Scripts
+  // ──────────────────────────────────────────────────────────────────────────
+  // ENTRY 9 — Automation Scripts (REWRITTEN — added nonce-check, create-only, verbose)
+  // ──────────────────────────────────────────────────────────────────────────
   createKnowledgeEntry(
     'best_practice',
     `# Using Koperator in Unattended/Automated Scripts
@@ -918,63 +993,96 @@ Always include both --payable and --payableBySC if your contract handles any pay
 When using koperator in unattended scripts (CI/CD, cron jobs, automated deployments), you MUST use these three flags together:
 
 ### Required Flags:
-1. \`--sign\` - Signs and broadcasts the transaction without user interaction
-2. \`--await\` - Waits for the transaction to be included in a block before returning
-3. \`--result-only\` - Outputs only the transaction result in clean JSON format
+1. \`--sign\` (-s) — Signs and broadcasts the transaction without user interaction
+2. \`--await\` — Waits for the transaction to be included in a block before returning
+3. \`--result-only\` — Outputs only the transaction result in clean JSON format (requires --await)
 
 ## Why These Flags Are Essential:
 
 ### Without --sign:
-- Script will hang waiting for user to confirm transaction
-- Terminal prompt: "Do you want to sign? (y/n)"
-- Script never continues
+- Script hangs waiting for user to confirm: "Do you want to sign? (y/n)"
 
 ### Without --await:
-- Script continues immediately after broadcasting
-- Transaction might fail but script won't know
-- No way to verify transaction success
+- Script continues immediately, transaction might fail without notice
 
 ### Without --result-only:
-- Output includes progress messages, ASCII art, logs
-- JSON result is mixed with text output
-- Cannot parse result programmatically
+- Output includes progress messages and logs mixed with JSON — unparseable
+
+## Additional Automation Flags:
+
+### --nonce-check (Nonce Strategy)
+Controls which nonce the operator uses for the transaction:
+- \`current\` (default): Uses the last confirmed nonce — safe for single-TX operations
+- \`first-pending\`: Uses the first pending nonce — useful for replacing a stuck TX
+- \`pending\`: Uses the next pending nonce — use for rapid sequential TXs
+
+\`\`\`bash
+# Send multiple TXs in rapid succession:
+~/klever-sdk/koperator sc invoke CONTRACT func1 \\
+    --nonce-check pending --sign --await --result-only
+
+~/klever-sdk/koperator sc invoke CONTRACT func2 \\
+    --nonce-check pending --sign --await --result-only
+\`\`\`
+
+### --create-only (-c) — Offline TX Generation
+Builds the TX JSON without broadcasting. Useful for:
+- Offline signing workflows
+- Multi-sig setups
+- TX review before broadcast
+
+\`\`\`bash
+~/klever-sdk/koperator sc invoke CONTRACT withdraw \\
+    --create-only > unsigned_tx.json
+# Sign and broadcast later
+\`\`\`
+
+### --verbose — Debug Logging
+Enables trace-level logging. Useful for debugging failed transactions:
+\`\`\`bash
+~/klever-sdk/koperator sc invoke CONTRACT func \\
+    --args "u32:42" \\
+    --verbose --sign --await --result-only
+\`\`\`
+
+### --kdaFee — Pay Gas with KDA Token
+Pay transaction fees with a specific KDA token instead of KLV:
+\`\`\`bash
+~/klever-sdk/koperator sc invoke CONTRACT func \\
+    --kdaFee "USDT-A1B2" \\
+    --sign --await --result-only
+\`\`\`
 
 ## Correct Usage in Scripts:
 
 ### ✅ CORRECT - Automated Deployment Script
 \`\`\`bash
 #!/bin/bash
-set -e  # Exit on error
+set -e
 
-# Deploy contract and capture result
 RESULT=$(KLEVER_NODE=https://node.testnet.klever.org \\
     ~/klever-sdk/koperator \\
     --key-file="$HOME/klever-sdk/walletKey.pem" \\
     sc create \\
     --wasm="output/contract.wasm" \\
-    --upgradeable --readable --payable --payableBySC \\
-    --sign \\        # No user interaction
-    --await \\       # Wait for confirmation
-    --result-only)   # Clean JSON output
+    --readable --payable --payableBySC \\
+    --sign --await --result-only)
 
-# Parse contract address from result
 CONTRACT_ADDRESS=$(echo "$RESULT" | jq -r '.contractAddress')
 echo "Deployed to: $CONTRACT_ADDRESS"
 \`\`\`
 
 ### ✅ CORRECT - CI/CD Pipeline
 \`\`\`yaml
-# .github/workflows/deploy.yml
 - name: Deploy Smart Contract
   run: |
     ~/klever-sdk/koperator \\
       --key-file="\${KEY_FILE}" \\
       sc create \\
       --wasm="output/contract.wasm" \\
-      --upgradeable --readable --payable \\
+      --readable --payable \\
       --sign --await --result-only > deployment.json
-    
-    # Extract and save contract address
+
     CONTRACT_ADDR=$(jq -r '.contractAddress' deployment.json)
     echo "CONTRACT_ADDRESS=\${CONTRACT_ADDR}" >> $GITHUB_ENV
 \`\`\`
@@ -982,19 +1090,19 @@ echo "Deployed to: $CONTRACT_ADDRESS"
 ### ✅ CORRECT - Automated Testing Script
 \`\`\`bash
 #!/bin/bash
+set -e
 
-# Function to invoke contract and check result
 invoke_and_verify() {
     local function_name=$1
     local expected_status=$2
-    
+
     RESULT=$(~/klever-sdk/koperator \\
         --key-file="$HOME/klever-sdk/walletKey.pem" \\
         sc invoke "$CONTRACT_ADDRESS" "$function_name" \\
         --sign --await --result-only)
-    
+
     STATUS=$(echo "$RESULT" | jq -r '.status')
-    
+
     if [ "$STATUS" != "$expected_status" ]; then
         echo "Error: Expected $expected_status, got $STATUS"
         echo "Full result: $RESULT"
@@ -1002,7 +1110,6 @@ invoke_and_verify() {
     fi
 }
 
-# Run tests
 invoke_and_verify "initialize" "success"
 invoke_and_verify "deposit" "success"
 \`\`\`
@@ -1011,41 +1118,22 @@ invoke_and_verify "deposit" "success"
 \`\`\`bash
 # WRONG - Missing --sign, will wait for user input
 ~/klever-sdk/koperator sc invoke CONTRACT transfer \\
-    --args "Address:klv1..." \\
-    --await --result-only
+    --args "address:klv1..." --await --result-only
 
 # WRONG - Missing --await, won't know if transaction succeeded
 ~/klever-sdk/koperator sc invoke CONTRACT transfer \\
-    --args "Address:klv1..." \\
-    --sign --result-only
+    --args "address:klv1..." --sign --result-only
 
 # WRONG - Missing --result-only, output not parseable
 ~/klever-sdk/koperator sc invoke CONTRACT transfer \\
-    --args "Address:klv1..." \\
-    --sign --await
+    --args "address:klv1..." --sign --await
 \`\`\`
 
 ## Parsing the JSON Result:
 
-### With --result-only, you get clean JSON:
-\`\`\`json
-{
-  "txHash": "abc123...",
-  "status": "success",
-  "contractAddress": "klv1...",
-  "gasUsed": 5000000,
-  "returnData": ["0x01"],
-  "logs": []
-}
-\`\`\`
-
-### Parse with jq:
 \`\`\`bash
 # Get transaction hash
 TX_HASH=$(echo "$RESULT" | jq -r '.txHash')
-
-# Get status
-STATUS=$(echo "$RESULT" | jq -r '.status')
 
 # Check if successful
 if [ "$(echo "$RESULT" | jq -r '.status')" = "success" ]; then
@@ -1060,27 +1148,18 @@ fi
 
 \`\`\`bash
 #!/bin/bash
-
-# Set environment for script
 export KLEVER_NODE="https://node.testnet.klever.org"
 export KEY_FILE="$HOME/klever-sdk/walletKey.pem"
 
-# Now all koperator commands use these settings
 ~/klever-sdk/koperator \\
     --key-file="$KEY_FILE" \\
     sc invoke CONTRACT_ADDRESS function_name \\
     --sign --await --result-only
-\`\`\`
-
-## Summary:
-- **Always use**: \`--sign --await --result-only\` for scripts
-- **Never forget**: All three flags are required for automation
-- **Parse output**: Use jq or similar to extract data from JSON result
-- **Set -e**: Use \`set -e\` in bash scripts to exit on errors`,
+\`\`\``,
     {
       title: 'Using Koperator in Unattended/Automated Scripts',
       description:
-        'CRITICAL: How to use koperator in CI/CD, automated scripts, and unattended environments',
+        'CRITICAL: --sign --await --result-only for automation. Plus --nonce-check, --create-only, --verbose, --kdaFee',
       tags: [
         'koperator',
         'automation',
@@ -1090,6 +1169,8 @@ export KEY_FILE="$HOME/klever-sdk/walletKey.pem"
         'sign',
         'await',
         'result-only',
+        'nonce-check',
+        'create-only',
         'critical',
       ],
       language: 'bash',
@@ -1099,7 +1180,9 @@ export KEY_FILE="$HOME/klever-sdk/walletKey.pem"
     }
   ),
 
-  // Koperator Missing Detection and Installation
+  // ──────────────────────────────────────────────────────────────────────────
+  // ENTRY 10 — Installation Guide (KEPT from original)
+  // ──────────────────────────────────────────────────────────────────────────
   createKnowledgeEntry(
     'error_pattern',
     `# Koperator Not Found - Detection and Installation Guide
@@ -1265,7 +1348,9 @@ done
     }
   ),
 
-  // Common Mistakes When Using Klever Tools
+  // ──────────────────────────────────────────────────────────────────────────
+  // ENTRY 11 — Common Mistakes (KEPT from original)
+  // ──────────────────────────────────────────────────────────────────────────
   createKnowledgeEntry(
     'best_practice',
     `# Common Mistakes When Using Klever Tools
@@ -1286,8 +1371,8 @@ KLEVER_NODE=http://localhost:8080 \\
     --key-file="walletKey.pem" \\
     sc create \\
     --wasm="contract.wasm" \\
-    --upgradeable --readable --payable \\
-    --await --sign --result-only
+    --readable --payable \\
+    --sign --await --result-only
 \`\`\`
 
 ## Key Points to Remember:
@@ -1346,6 +1431,22 @@ mxpy contract build
 ~/klever-sdk/ksc all build
 \`\`\`
 
+### ❌ Wrong Argument Syntax
+\`\`\`bash
+# WRONG - Old/incorrect patterns
+--args "Option:String:hello"    # Wrong Option syntax
+--args "List:u32:1,u32:2"       # No single-arg List syntax
+--args "tuple:u64:123,String:x" # No single-arg tuple syntax
+\`\`\`
+
+### ✅ Correct Argument Syntax
+\`\`\`bash
+# CORRECT
+--args "optionstring:hello"     # option prefix (no colon separator)
+--args "u32:1" --args "u32:2"   # List: separate --args per element
+--args "u64:123" --args "string:x" # Tuple: separate --args per element
+\`\`\`
+
 ### ❌ Wrong Query Method
 \`\`\`bash
 # WRONG - koperator doesn't do queries
@@ -1360,15 +1461,19 @@ curl -s 'https://api.testnet.klever.org/v1.0/sc/query' \\
 \`\`\``,
     {
       title: 'Common Mistakes When Using Klever Tools',
-      description: 'Frequent mistakes developers make with Klever CLI tools and how to avoid them',
-      tags: ['mistakes', 'best-practice', 'koperator', 'cli', 'errors', 'debugging'],
+      description:
+        'Frequent mistakes with Klever CLI tools: wrong commands, wrong arg syntax (Option/List/Tuple), and corrections',
+      tags: ['mistakes', 'best-practice', 'koperator', 'cli', 'errors', 'debugging', 'smart-contract'],
       language: 'bash',
       relevanceScore: 0.9,
       contractType: 'any',
       author: 'klever-mcp',
     }
   ),
-  // KDA Token Creation with Koperator
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // ENTRY 12 — KDA Token Creation (KEPT from original)
+  // ──────────────────────────────────────────────────────────────────────────
   createKnowledgeEntry(
     'deployment_tool',
     `# Creating KDA Tokens with Koperator
@@ -1587,7 +1692,8 @@ echo "Created token: $TOKEN_ID"  # e.g., MYTK-A1B2
 - ❌ Not having enough KLV balance (need 20,000 KLV + gas fees)`,
     {
       title: 'Creating KDA Tokens with Koperator',
-      description: 'Complete guide to creating KDA tokens (fungible, NFT, SFT) using koperator kda create command',
+      description:
+        'Complete guide to creating KDA tokens (fungible, NFT, SFT) using koperator kda create command',
       tags: ['koperator', 'kda', 'token', 'create', 'nft', 'sft', 'fungible', 'deployment'],
       language: 'bash',
       relevanceScore: 1.0,

--- a/src/knowledge/tools/koperator.ts
+++ b/src/knowledge/tools/koperator.ts
@@ -1734,6 +1734,178 @@ echo "Created token: $TOKEN_ID"  # e.g., MYTK-A1B2
       author: 'klever-mcp',
     }
   ),
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // ENTRY 13 — sc upgrade: Contract Upgrade Command (NEW)
+  // ──────────────────────────────────────────────────────────────────────────
+  createKnowledgeEntry(
+    'deployment_tool',
+    `# Koperator sc upgrade — Contract Upgrade Command
+
+## Overview
+
+\`sc upgrade\` replaces the bytecode and metadata of an **already-deployed** smart contract with a new WASM binary. The contract address remains unchanged. The caller must be the **contract owner** (the account that originally deployed it), and the contract must have been deployed with \`--upgradeable\` (which defaults to true).
+
+- **Transaction type**: SmartContract_SCInvoke (NOT SCDeploy)
+- **Target**: The existing contract address (first positional argument)
+- **Alias**: \`sc usc\`
+
+## Full Syntax
+
+\`\`\`bash
+~/klever-sdk/koperator \\
+    --key-file=<pem> \\
+    sc upgrade <CONTRACT_BECH32_ADDRESS> \\
+    --wasm=<path/to/contract.wasm> \\
+    [--args <type:value>]... \\
+    [--values 'KLV=amount,...'] \\
+    [--payable] [--upgradeable] [--payableBySC] [--readable] \\
+    --sign --await --result-only
+\`\`\`
+
+## Positional Arguments
+
+| Position | Required | Description |
+|----------|----------|-------------|
+| 0 | **Yes** | bech32 \`klv1…\` address of the contract to upgrade |
+| 1 | No | Optional raw hex appended verbatim to payload (rarely used) |
+
+## Command-Specific Flag
+
+| Flag | Type | Default | Required | Description |
+|------|------|---------|----------|-------------|
+| \`--wasm\` | string | \`""\` | **Yes** | Path to the new \`.wasm\` binary file |
+
+## ⚠️ CRITICAL: Metadata Is REPLACED, Not Merged
+
+The metadata flags (\`--payable\`, \`--upgradeable\`, \`--payableBySC\`, \`--readable\`) **replace the contract's existing metadata entirely**. They are NOT inherited from the original deployment.
+
+If you previously deployed with \`--payable\` but omit it on upgrade, **the contract will no longer be payable**.
+
+→ Always re-specify ALL desired metadata flags on every upgrade.
+
+## Differences from sc create and sc invoke
+
+| Aspect | sc create | sc upgrade | sc invoke |
+|--------|-----------|------------|-----------|
+| TX type | SCDeploy | SCInvoke | SCInvoke |
+| Target | Zero address (auto) | Existing contract | Existing contract |
+| Requires --wasm | Yes | Yes | No |
+| Data prefix | \`<bytecode>@<vmType>@<metadata>\` | \`upgradeContract@<bytecode>@<metadata>\` | \`<functionName>\` |
+| Metadata flags | Yes | Yes (replaces!) | No (ignored) |
+| vmType | Included | NOT included | N/A |
+
+## Examples
+
+### Basic upgrade (keep upgradeable)
+\`\`\`bash
+KLEVER_NODE=https://node.testnet.klever.org \\
+    ~/klever-sdk/koperator \\
+    --key-file="$HOME/klever-sdk/walletKey.pem" \\
+    sc upgrade klv1qqqqcontract_address_here \\
+    --wasm=./output/contract_v2.wasm \\
+    --upgradeable \\
+    --sign --await --result-only
+\`\`\`
+
+### Upgrade with full metadata re-specification
+\`\`\`bash
+KLEVER_NODE=https://node.testnet.klever.org \\
+    ~/klever-sdk/koperator \\
+    --key-file="$HOME/klever-sdk/walletKey.pem" \\
+    sc upgrade klv1qqqqcontract_address_here \\
+    --wasm=./output/contract_v2.wasm \\
+    --upgradeable --readable --payable --payableBySC \\
+    --sign --await --result-only
+\`\`\`
+
+### Upgrade with constructor arguments
+If the upgrade constructor requires initialization parameters:
+\`\`\`bash
+KLEVER_NODE=https://node.testnet.klever.org \\
+    ~/klever-sdk/koperator \\
+    --key-file="$HOME/klever-sdk/walletKey.pem" \\
+    sc upgrade klv1qqqqcontract_address_here \\
+    --wasm=./output/contract_v2.wasm \\
+    --args "u64:42" \\
+    --args "address:klv1abc..." \\
+    --args "string:hello" \\
+    --upgradeable --payable \\
+    --sign --await --result-only
+\`\`\`
+
+### Upgrade with token transfer
+\`\`\`bash
+~/klever-sdk/koperator \\
+    --key-file="$HOME/klever-sdk/walletKey.pem" \\
+    sc upgrade klv1qqqqcontract_address_here \\
+    --wasm=./output/contract_v2.wasm \\
+    --values 'KLV=1000000' \\
+    --upgradeable \\
+    --sign --await --result-only
+\`\`\`
+
+### Scripted upgrade (capture result)
+\`\`\`bash
+RESULT=$(KLEVER_NODE=https://node.testnet.klever.org \\
+    ~/klever-sdk/koperator \\
+    --key-file="$HOME/klever-sdk/walletKey.pem" \\
+    sc upgrade klv1qqqqcontract_address_here \\
+    --wasm=./output/contract_v2.wasm \\
+    --upgradeable --readable --payable --payableBySC \\
+    --sign --await --result-only)
+TX_HASH=$(echo "$RESULT" | jq -r '.hash')
+echo "Upgrade TX: $TX_HASH"
+\`\`\`
+
+## ⚠️ Storage Persistence on Upgrade
+
+Contract storage is **preserved** across upgrades — all existing data remains in place. This means:
+
+- ✅ Existing storage values, mappings, and sets survive the upgrade unchanged
+- ⚠️ You MUST keep the same storage key names and data layout for existing fields
+- ⚠️ Changing a storage mapper type (e.g. SingleValueMapper → MapMapper) or its value type (e.g. u64 → BigUint) **corrupts existing data** — the bytes in storage will be deserialized with the wrong codec
+- ✅ Adding NEW storage fields is safe — they start empty
+- ❌ Removing or renaming a storage field does NOT delete its data — the bytes remain in storage unused
+- ⚠️ Reordering struct fields that are stored as a single blob will break deserialization
+
+**Best practice**: Only add new storage fields. Never change the type or layout of existing ones. If a data migration is needed, add a new field with the new type and write a one-time migration endpoint that reads old data and writes it to the new field.
+
+## Error Reference
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| \`invalid receiver <addr>\` | Malformed bech32 address | Provide valid klv1… contract address |
+| \`invalid file path provided\` | --wasm is empty or missing | Supply the path to the new .wasm file |
+| \`failed to read file\` | WASM file not found or unreadable | Verify path exists; did you run build? |
+| Permission denied | Caller is not the contract owner | Use the owner wallet's key file |
+| Contract not upgradeable | Contract was deployed without --upgradeable | Cannot upgrade; must redeploy |
+
+## Common Mistakes
+- ❌ Omitting metadata flags assuming they carry over from deploy — they DON'T
+- ❌ Using a non-owner wallet — only the original deployer can upgrade
+- ❌ Forgetting --wasm flag — it's required for upgrade
+- ❌ Trying to upgrade a contract deployed without --upgradeable`,
+    {
+      title: 'Koperator sc upgrade — Contract Upgrade Command',
+      description:
+        'Complete reference for sc upgrade: syntax, metadata replacement, differences from sc create/invoke, examples, error reference',
+      tags: [
+        'koperator',
+        'upgrade',
+        'sc-upgrade',
+        'deployment',
+        'metadata',
+        'wasm',
+        'smart-contract',
+        'reference',
+      ],
+      language: 'bash',
+      relevanceScore: 1.0,
+      contractType: 'any',
+      author: 'klever-mcp',
+    }
+  ),
 ];
 
 export default koperatorKnowledge;

--- a/src/knowledge/tools/koperator.ts
+++ b/src/knowledge/tools/koperator.ts
@@ -50,6 +50,7 @@ Note: \`--upgradeable\` **defaults to true**. Omit it only when you want an immu
 - \`--token-transfers\` ❌ WRONG — use \`--values\`
 - \`Option:String:hello\` ❌ WRONG — use \`optionstring:hello\` (no colon between option and type)
 - \`List:u32:1,u32:2\` ❌ WRONG — no single-arg list syntax; pass each element as separate \`--args\`
+- \`--args "hex:0x1a2b3c"\` ❌ WRONG — hex type must NOT have 0x prefix, use \`hex:1a2b3c\`
 
 ## Correct Examples:
 
@@ -262,6 +263,8 @@ export KLEVER_NODE="https://node.testnet.klever.org"
     `# Koperator Argument Types — Complete Reference
 
 Every \`--args\` value follows the pattern \`<type>:<value>\` where type is case-insensitive.
+The type prefix is **mandatory** — there is no auto-detection without it (except \`number:\` which auto-selects integer width).
+Numeric values must NOT include underscores or thousand separators (e.g. use \`1000000\`, not \`1_000_000\`).
 
 ## Supported Types & Aliases
 
@@ -350,11 +353,22 @@ There is **NO single-arg syntax** for List, Tuple, or Variadic. Pass each elemen
 
 ## Token Payments (--values, NOT --args)
 
+⚠️ **--values amounts are in RAW smallest units** (not display amounts).
+Each token has its own precision (0–8 decimal places). You MUST multiply by 10^decimals.
+KLV has 6 decimals → 1 KLV = 1000000 raw. KFI has 6 decimals → 1 KFI = 1000000 raw.
+A custom KDA token with 8 decimals → 1 token = 100000000 raw.
+A custom KDA token with 0 decimals → 1 token = 1 raw.
+This is different from \`koperator account send\` which accepts display amounts directly.
+
+**Formula**: raw_amount = display_amount × 10^token_precision
+
 Payments use \`--values\` with \`=\` syntax:
 \`\`\`bash
---values "KLV=1000000"                     # Single token (1 KLV, 6 decimals)
+--values "KLV=1000000"                     # 1 KLV (precision 6 → 1×10^6)
+--values "KLV=10000000"                    # 10 KLV
 --values "KLV=1000000,KFI=500000"          # Multiple tokens
---values "NFT-XY01/01=1"                   # NFT with nonce
+--values "MYTKN-a1b2=100000000"            # 1 MYTKN (if precision=8 → 1×10^8)
+--values "NFT-XY01/01=1"                   # NFT (precision 0, nonce 01)
 --values "SFT-AB12/05=100"                 # SFT with nonce
 \`\`\`
 
@@ -1437,6 +1451,7 @@ mxpy contract build
 --args "Option:String:hello"    # Wrong Option syntax
 --args "List:u32:1,u32:2"       # No single-arg List syntax
 --args "tuple:u64:123,String:x" # No single-arg tuple syntax
+--args "hex:0xdeadbeef"         # 0x prefix causes "invalid item to encode" error
 \`\`\`
 
 ### ✅ Correct Argument Syntax
@@ -1445,6 +1460,24 @@ mxpy contract build
 --args "optionstring:hello"     # option prefix (no colon separator)
 --args "u32:1" --args "u32:2"   # List: separate --args per element
 --args "u64:123" --args "string:x" # Tuple: separate --args per element
+--args "hex:deadbeef"           # hex: NO 0x prefix, raw hex digits only
+\`\`\`
+
+### ❌ Wrong Payment Amount
+\`\`\`bash
+# WRONG - display amounts don't work in --values
+--values "KLV=10"              # This sends 0.00001 KLV, not 10 KLV!
+--klv=500000000                # --klv flag does not exist
+\`\`\`
+
+### ✅ Correct Payment Amount
+\`\`\`bash
+# CORRECT - --values uses raw smallest units: amount × 10^precision
+# Token precision ranges from 0 to 8 decimals (check each token's precision!)
+--values "KLV=10000000"        # 10 KLV (precision=6, 10 × 10^6)
+--values "KLV=500000000"       # 500 KLV (precision=6, 500 × 10^6)
+--values "MYTKN-a1b2=100000000" # 1 MYTKN (precision=8, 1 × 10^8)
+--values "NFT-XY01/01=1"       # 1 NFT (precision=0, nonce 01)
 \`\`\`
 
 ### ❌ Wrong Query Method

--- a/src/knowledge/tools/koperator.ts
+++ b/src/knowledge/tools/koperator.ts
@@ -539,7 +539,7 @@ Value used as-is with no transformation. Must provide valid hex.
 |----------|-----|-----------|
 | \`optionu32:100\` | \`0100000064\` | 01 (Some) + 00000064 (u32 nested: 4 bytes) |
 | \`optionu64:1\` | \`010000000000000001\` | 01 (Some) + 8-byte u64 |
-| \`optionstring:abc\` | \`010000000361626363\` | 01 + 00000003 (length) + 616263 |
+| \`optionstring:abc\` | \`0100000003616263\` | 01 + 00000003 (length) + 616263 |
 | \`optionbool:true\` | \`0101\` | 01 (Some) + 01 (true) |
 | \`optionbool:false\` | \`0100\` | 01 (Some) + 00 (false, nested) |
 | \`empty:\` | *(empty)* | None |
@@ -880,8 +880,10 @@ KLEVER_NODE=https://node.testnet.klever.org \\
 ~/klever-sdk/koperator \\
     --key-file="$HOME/klever-sdk/walletKey.pem" \\
     sc invoke klv1contract_address_here withdraw \\
-    --create-only
-# Outputs unsigned TX JSON to stdout for later signing`,
+    --sign --create-only
+# Outputs signed TX JSON to stdout without broadcasting.
+# --create-only always signs the TX; --sign skips the interactive confirmation prompt.
+# For automation, always pair with --sign to avoid hanging on the prompt.`,
     {
       title: 'Koperator Smart Contract Operations Examples',
       description:
@@ -952,12 +954,11 @@ These flags set the contract's code metadata during deployment or upgrade:
 
 ### Immutable Production Contract
 \`\`\`bash
-# Explicitly omit --upgradeable to make immutable
---readable --payable --payableBySC
-# Since --upgradeable defaults to true, consider using:
-# sc create ... (without --upgradeable won't help; the flag is true by default)
-# To make truly immutable, deploy without --upgradeable and it's still upgradeable!
-# Immutability requires NOT setting the upgradeable flag in code metadata.
+# --upgradeable defaults to TRUE, so omitting it still leaves the contract upgradeable.
+# You must explicitly set --upgradeable=false to make the contract immutable:
+--readable --payable --payableBySC --upgradeable=false
+# WARNING: An immutable contract can NEVER be upgraded or patched.
+# Metadata hex will be 0006 (Payable + PayableBySC, no Upgradeable bit).
 \`\`\`
 
 ## Common Mistakes
@@ -1146,8 +1147,8 @@ invoke_and_verify "deposit" "success"
 ## Parsing the JSON Result:
 
 \`\`\`bash
-# Get transaction hash
-TX_HASH=$(echo "$RESULT" | jq -r '.txHash')
+# Get transaction hash (operator stdout uses "hash", not "txHash")
+TX_HASH=$(echo "$RESULT" | jq -r '.hash')
 
 # Check if successful
 if [ "$(echo "$RESULT" | jq -r '.status')" = "success" ]; then

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -255,14 +255,14 @@ export class KleverMCPServer {
       {
         name: 'search_documentation',
         description:
-          'Search Klever VM documentation and knowledge base. Returns human-readable markdown with titles, descriptions, and code snippets. Optimized for "how do I..." questions. Use this instead of query_context when you need formatted developer documentation.',
+          'Search Klever VM documentation and knowledge base. Returns human-readable markdown with titles, descriptions, and code snippets. Covers koperator CLI syntax (sc invoke, sc create, sc deploy, sc upgrade), --args type prefixes, --values payment flags, contract metadata flags, ABI decoding, and all smart contract development topics. ALWAYS use this tool first when you need to know the correct flags or argument syntax for koperator commands. Use this instead of query_context when you need formatted developer documentation.',
         inputSchema: {
           type: 'object' as const,
           properties: {
             query: {
               type: 'string',
               description:
-                'Search query in natural language (e.g. "how to use storage mappers", "deploy contract to testnet", "handle KDA token transfers").',
+                'Search query in natural language (e.g. "how to use storage mappers", "koperator sc invoke payment values", "deploy contract to testnet", "--args type prefixes", "handle KDA token transfers").',
             },
             category: {
               type: 'string',

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -255,7 +255,7 @@ export class KleverMCPServer {
       {
         name: 'search_documentation',
         description:
-          'Search Klever VM documentation and knowledge base. Returns human-readable markdown with titles, descriptions, and code snippets. Covers koperator CLI syntax (sc invoke, sc create, sc deploy, sc upgrade), --args type prefixes, --values payment flags, contract metadata flags, ABI decoding, and all smart contract development topics. ALWAYS use this tool first when you need to know the correct flags or argument syntax for koperator commands. Use this instead of query_context when you need formatted developer documentation.',
+          'Search Klever VM documentation and knowledge base. Returns human-readable markdown with titles, descriptions, and code snippets. Covers koperator CLI syntax (sc invoke, sc create, sc upgrade), --args type prefixes, --values payment flags, contract metadata flags, ABI decoding, and all smart contract development topics. ALWAYS use this tool first when you need to know the correct flags or argument syntax for koperator commands. Use this instead of query_context when you need formatted developer documentation.',
         inputSchema: {
           type: 'object' as const,
           properties: {

--- a/src/storage/memory.ts
+++ b/src/storage/memory.ts
@@ -70,7 +70,8 @@ export class InMemoryStorage implements StorageBackend {
     // Search in content and metadata using token-based matching
     if (params.query) {
       const queryTokens = params.query.toLowerCase().split(/\s+/).filter(Boolean);
-      results = results.filter(ctx => {
+      const threshold = Math.max(1, Math.ceil(queryTokens.length * 0.4));
+      const scored = results.map(ctx => {
         const searchable = [
           ctx.content,
           ctx.metadata.title,
@@ -80,12 +81,19 @@ export class InMemoryStorage implements StorageBackend {
           .join(' ')
           .toLowerCase();
 
-        return queryTokens.every(token => searchable.includes(token));
+        const matchCount = queryTokens.filter(token => searchable.includes(token)).length;
+        return { ctx, matchRatio: matchCount / queryTokens.length };
       });
+      results = scored
+        .filter(s => s.matchRatio >= threshold / queryTokens.length)
+        .sort((a, b) => b.matchRatio - a.matchRatio)
+        .map(s => s.ctx);
     }
 
-    // Sort by relevance score (descending)
-    results.sort((a, b) => (b.metadata.relevanceScore || 0) - (a.metadata.relevanceScore || 0));
+    // Sort by relevance score (descending) — secondary to query match ratio
+    if (!params.query) {
+      results.sort((a, b) => (b.metadata.relevanceScore || 0) - (a.metadata.relevanceScore || 0));
+    }
 
     // Apply pagination
     const start = params.offset || 0;

--- a/src/storage/memory.ts
+++ b/src/storage/memory.ts
@@ -70,6 +70,7 @@ export class InMemoryStorage implements StorageBackend {
     // Search in content and metadata using token-based matching
     if (params.query) {
       const queryTokens = params.query.toLowerCase().split(/\s+/).filter(Boolean);
+      if (queryTokens.length === 0) return results.slice(params.offset || 0, (params.offset || 0) + (params.limit || 10));
       const threshold = Math.max(1, Math.ceil(queryTokens.length * 0.4));
       const scored = results.map(ctx => {
         const searchable = [
@@ -86,11 +87,11 @@ export class InMemoryStorage implements StorageBackend {
       });
       results = scored
         .filter(s => s.matchRatio >= threshold / queryTokens.length)
-        .sort((a, b) => b.matchRatio - a.matchRatio)
+        .sort((a, b) => b.matchRatio - a.matchRatio || (b.ctx.metadata.relevanceScore || 0) - (a.ctx.metadata.relevanceScore || 0))
         .map(s => s.ctx);
     }
 
-    // Sort by relevance score (descending) — secondary to query match ratio
+    // When no query, sort by relevance score alone (with query, tie-breaking is handled above)
     if (!params.query) {
       results.sort((a, b) => (b.metadata.relevanceScore || 0) - (a.metadata.relevanceScore || 0));
     }

--- a/src/storage/redis.ts
+++ b/src/storage/redis.ts
@@ -133,7 +133,8 @@ export class RedisStorage implements StorageBackend {
 
     if (params.query) {
       const queryTokens = params.query.toLowerCase().split(/\s+/).filter(Boolean);
-      results = results.filter(ctx => {
+      const threshold = Math.max(1, Math.ceil(queryTokens.length * 0.4));
+      const scored = results.map(ctx => {
         const searchable = [
           ctx.content,
           ctx.metadata.title,
@@ -143,12 +144,19 @@ export class RedisStorage implements StorageBackend {
           .join(' ')
           .toLowerCase();
 
-        return queryTokens.every(token => searchable.includes(token));
+        const matchCount = queryTokens.filter(token => searchable.includes(token)).length;
+        return { ctx, matchRatio: matchCount / queryTokens.length };
       });
+      results = scored
+        .filter(s => s.matchRatio >= threshold / queryTokens.length)
+        .sort((a, b) => b.matchRatio - a.matchRatio)
+        .map(s => s.ctx);
     }
 
-    // Sort by relevance score
-    results.sort((a, b) => (b.metadata.relevanceScore || 0) - (a.metadata.relevanceScore || 0));
+    // Sort by relevance score — secondary to query match ratio
+    if (!params.query) {
+      results.sort((a, b) => (b.metadata.relevanceScore || 0) - (a.metadata.relevanceScore || 0));
+    }
 
     // Apply pagination
     const start = params.offset || 0;

--- a/src/storage/redis.ts
+++ b/src/storage/redis.ts
@@ -133,6 +133,7 @@ export class RedisStorage implements StorageBackend {
 
     if (params.query) {
       const queryTokens = params.query.toLowerCase().split(/\s+/).filter(Boolean);
+      if (queryTokens.length === 0) return results.slice(params.offset || 0, (params.offset || 0) + (params.limit || 10));
       const threshold = Math.max(1, Math.ceil(queryTokens.length * 0.4));
       const scored = results.map(ctx => {
         const searchable = [
@@ -149,11 +150,11 @@ export class RedisStorage implements StorageBackend {
       });
       results = scored
         .filter(s => s.matchRatio >= threshold / queryTokens.length)
-        .sort((a, b) => b.matchRatio - a.matchRatio)
+        .sort((a, b) => b.matchRatio - a.matchRatio || (b.ctx.metadata.relevanceScore || 0) - (a.ctx.metadata.relevanceScore || 0))
         .map(s => s.ctx);
     }
 
-    // Sort by relevance score — secondary to query match ratio
+    // When no query, sort by relevance score alone (with query, tie-breaking is handled above)
     if (!params.query) {
       results.sort((a, b) => (b.metadata.relevanceScore || 0) - (a.metadata.relevanceScore || 0));
     }

--- a/src/utils/project-init-script.ts
+++ b/src/utils/project-init-script.ts
@@ -377,7 +377,7 @@ export const projectInitToolDefinition = {
 export const addHelperScriptsToolDefinition = {
   name: 'add_helper_scripts',
   description:
-    'Add build, deploy, upgrade, query, test, and interact automation scripts to an existing Klever smart contract project. Creates a scripts/ directory with bash scripts and updates .gitignore. Run this from the project root directory (where Cargo.toml is located).',
+    'Add build, deploy, upgrade, query, test, and interact automation scripts to an existing Klever smart contract project. Creates a scripts/ directory with bash scripts and updates .gitignore. Run this from the project root directory (where Cargo.toml is located). This tool generates scaffold files — for koperator CLI syntax reference (correct flags like --args, --values for payments), use search_documentation instead.',
   inputSchema: {
     type: 'object',
     properties: {


### PR DESCRIPTION
## Summary

Comprehensive rewrite and expansion of koperator CLI knowledge base entries, plus a critical fix to the search algorithm that was preventing AI agents from finding documentation.

## Problem

AI agents using the MCP server could not find koperator documentation when searching with natural language queries (e.g. "koperator sc invoke smart contract call function with KLV payment"). The search returned zero results because the token matching algorithm required ALL query words to appear in the entry. Agents then fell back to running `koperator --help` or used wrong flags like `--klv` instead of `--values "KLV=amount"`.

Additionally, the existing koperator knowledge base had significant gaps:
- Incorrect `Option` syntax (`Option:String:hello` instead of `optionstring:hello`)
- Missing argument type prefixes and encoding rules
- No ABI-to-command mapping documentation
- No global flags reference
- No dedicated `sc upgrade` documentation
- No `sc parse-output` decoding reference
- Missing details on `--values` raw unit amounts and token precision

## Solution

1. **Fixed search algorithm** in both storage backends to use threshold-based matching (40% of tokens) instead of strict all-tokens matching
2. **Rewrote koperator knowledge entries** from authoritative source (`operator-sc-invoke-create.md` extracted from koperator source code)
3. **Added new knowledge modules** for ABI mapping, global flags, and sc upgrade
4. **Improved tool descriptions** to guide agents toward `search_documentation` for syntax questions

## Key Changes

- **New:**
  - `src/knowledge/tools/koperator-abi.ts` — 2 entries: ABI→command mapping for encoding inputs + `sc parse-output` decoding reference
  - `src/knowledge/tools/koperator-global-flags.ts` — 2 entries: authentication/network/TX construction flags + signing/output/automation flags
  - Entry 13 in `koperator.ts` — dedicated `sc upgrade` reference (syntax, metadata replacement, storage persistence, error reference)

- **Updated:**
  - `src/knowledge/tools/koperator.ts` — 7 of 12 entries rewritten with correct syntax from authoritative source; added hex `0x` prefix warning, `--values` raw unit/precision documentation, output JSON structure, mandatory type prefix note
  - `src/knowledge/tools/index.ts` — registered `koperator-abi` and `koperator-global-flags` modules
  - `src/storage/memory.ts` — search algorithm changed from `every` (100% match) to threshold-based (40% match) with match-ratio ranking
  - `src/storage/redis.ts` — same search algorithm fix as memory storage
  - `src/mcp/server.ts` — `search_documentation` description now mentions koperator CLI syntax, flags, and "ALWAYS use this tool first"
  - `src/utils/project-init-script.ts` — `add_helper_scripts` description now redirects to `search_documentation` for syntax reference

## Testing

- [x] All existing tests pass (`pnpm test` — 131 tests, 5 suites)
- [x] Build passes (`pnpm run build`)
- [x] Lint passes (`pnpm run lint`)
- [x] Manual testing: verified search queries like "koperator sc invoke smart contract call function with KLV payment" now return results instead of zero

## Configuration Changes

None.

## Breaking Changes

None. The search algorithm change is backwards-compatible — queries that matched before still match (they had 100% token match, which exceeds the 40% threshold). Queries that previously returned zero results now return relevant entries.

## Related Issues

Related to KLC-2262

## Checklist

- [x] Code follows project style guidelines
- [x] Tests added/updated and passing
- [x] Documentation updated
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] No unnecessary files included
- [x] Breaking changes documented above
- [x] Configuration changes documented above
