### PR TITLE
[KLC-2316] Add tests/scenarios to knowledge base

### DIFF
--- a/src/knowledge/index.ts
+++ b/src/knowledge/index.ts
@@ -17,6 +17,7 @@ import toolsKnowledge from './tools/index.js';
 import errorsKnowledge from './errors/index.js';
 import examplesKnowledge from './examples/index.js';
 import bestPracticesKnowledge from './best-practices/index.js';
+import testingKnowledge from './testing/index.js';
 
 /**
  * Complete Klever knowledge base
@@ -34,6 +35,7 @@ export const kleverKnowledge: KnowledgeEntry[] = [
   ...errorsKnowledge,
   ...examplesKnowledge,
   ...bestPracticesKnowledge,
+  ...testingKnowledge,
 ];
 
 // Also export individual categories for targeted access
@@ -49,6 +51,7 @@ export {
   errorsKnowledge,
   examplesKnowledge,
   bestPracticesKnowledge,
+  testingKnowledge,
 };
 
 // Export types for external use

--- a/src/knowledge/testing/blackbox-tests.ts
+++ b/src/knowledge/testing/blackbox-tests.ts
@@ -1,0 +1,421 @@
+import { createKnowledgeEntry, KnowledgeEntry } from '../types.js';
+
+export const blackboxTestsKnowledge: KnowledgeEntry[] = [
+  createKnowledgeEntry(
+    'code_example',
+    `# Blackbox Testing with ScenarioWorld (Modern API)
+
+The modern blackbox test API uses \`ScenarioWorld\` with a fluent \`.tx()\` / \`.query()\` builder. This is the **recommended approach** for new contracts.
+
+## When to Use
+- Full integration tests with real blockchain simulation
+- Testing deploy, upgrade, cross-contract calls
+- Generating scenario trace files (\`.scen.json\`)
+- Most readable and type-safe test approach
+
+## Setup
+
+\`\`\`rust
+use klever_sc_scenario::imports::*;
+use my_contract::*;  // imports your contract + proxy
+
+const OWNER_ADDRESS: TestAddress = TestAddress::new("owner");
+const SC_ADDRESS: TestSCAddress = TestSCAddress::new("my-contract");
+const CODE_PATH: KleverscPath = KleverscPath::new("output/my-contract.kleversc.json");
+
+fn world() -> ScenarioWorld {
+    let mut blockchain = ScenarioWorld::new();
+    blockchain.register_contract(CODE_PATH, my_contract::ContractBuilder);
+    blockchain
+}
+\`\`\`
+
+## Setting Up Accounts
+
+\`\`\`rust
+world
+    .account(OWNER_ADDRESS)
+    .nonce(1)
+    .balance(100)          // KLV balance
+    .account(OTHER_ADDRESS)
+    .nonce(2)
+    .balance(300)
+    .kda_balance(TOKEN_ID, 500)    // Fungible token balance
+    .commit();             // commit() persists to blockchain state
+\`\`\`
+
+## Deploying a Contract
+
+\`\`\`rust
+let new_address = world
+    .tx()
+    .from(OWNER_ADDRESS)
+    .typed(my_contract_proxy::MyContractProxy)
+    .init(5u32)                  // calls #[init] with arg
+    .code(CODE_PATH)
+    .new_address(SC_ADDRESS)     // pin the resulting address
+    .returns(ReturnsNewAddress)
+    .run();
+
+assert_eq!(new_address, SC_ADDRESS.to_address());
+\`\`\`
+
+## Querying a Contract (Read-Only)
+
+\`\`\`rust
+// Assert expected value inline
+world
+    .query()
+    .to(SC_ADDRESS)
+    .typed(my_contract_proxy::MyContractProxy)
+    .sum()
+    .returns(ExpectValue(5u32))
+    .run();
+
+// Or capture the return value
+let value = world
+    .query()
+    .to(SC_ADDRESS)
+    .typed(my_contract_proxy::MyContractProxy)
+    .sum()
+    .returns(ReturnsResultUnmanaged)
+    .run();
+assert_eq!(value, RustBigUint::from(5u32));
+\`\`\`
+
+## Calling an Endpoint
+
+\`\`\`rust
+world
+    .tx()
+    .from(OWNER_ADDRESS)
+    .to(SC_ADDRESS)
+    .typed(my_contract_proxy::MyContractProxy)
+    .add(1u32)
+    .run();
+\`\`\`
+
+## Checking Storage After a Call
+
+\`\`\`rust
+world
+    .check_account(SC_ADDRESS)
+    .check_storage("str:sum", "6");
+\`\`\`
+
+Or use the step-style:
+\`\`\`rust
+world.check_state_step(
+    CheckStateStep::new()
+        .put_account(OWNER_ADDRESS, CheckAccount::new())
+        .put_account(SC_ADDRESS, CheckAccount::new().check_storage("str:sum", "6")),
+);
+\`\`\`
+
+## Testing Multi-Value Return
+
+\`\`\`rust
+// Assert inline
+world
+    .tx()
+    .from(OTHER_ADDRESS)
+    .to(SC_ADDRESS)
+    .typed(my_contract_proxy::MyContractProxy)
+    .multi_return(1u32)
+    .returns(ExpectValue(MultiValue2((1u32, 2u32))))
+    .run();
+
+// Capture and assert
+let value = world
+    .tx()
+    .from(OTHER_ADDRESS)
+    .to(SC_ADDRESS)
+    .typed(my_contract_proxy::MyContractProxy)
+    .multi_return(1u32)
+    .returns(ReturnsResultUnmanaged)
+    .run();
+assert_eq!(value, MultiValue2((RustBigUint::from(1u32), RustBigUint::from(2u32))));
+\`\`\`
+
+## Testing Upgrade
+
+\`\`\`rust
+world
+    .tx()
+    .from(OWNER_ADDRESS)
+    .to(SC_ADDRESS)
+    .typed(my_contract_proxy::MyContractProxy)
+    .upgrade(100u64)
+    .code(CODE_PATH)
+    .run();
+
+world
+    .check_account(SC_ADDRESS)
+    .check_storage("str:sum", "100");
+\`\`\`
+
+## Generating a Scenario Trace
+
+\`\`\`rust
+world.start_trace();          // start recording before steps
+
+// ... perform tx, query, check_account calls ...
+
+world.write_scenario_trace("trace1.scen.json");  // saves a replayable .scen.json
+\`\`\`
+
+## NFT Balance in Account Setup
+
+\`\`\`rust
+world
+    .account(USER_ADDRESS)
+    .nonce(3)
+    .balance(50)
+    .kda_nft_balance(TOKEN_ID, 2u64, 1u64, ())   // (token, nonce, amount, attributes)
+    .commit();
+\`\`\`
+
+## Complete Test Example
+
+\`\`\`rust
+#[test]
+fn full_lifecycle_test() {
+    let mut world = world();
+
+    world.start_trace();
+
+    world
+        .account(OWNER_ADDRESS).nonce(1).balance(100)
+        .account(OTHER_ADDRESS).nonce(2).balance(300).kda_balance(TOKEN_ID, 500)
+        .commit();
+
+    // Deploy
+    world
+        .tx()
+        .from(OWNER_ADDRESS)
+        .typed(my_proxy::MyProxy)
+        .init(5u32)
+        .code(CODE_PATH)
+        .new_address(SC_ADDRESS)
+        .run();
+
+    // Query initial state
+    world
+        .query()
+        .to(SC_ADDRESS)
+        .typed(my_proxy::MyProxy)
+        .sum()
+        .returns(ExpectValue(5u32))
+        .run();
+
+    // Call add
+    world
+        .tx()
+        .from(OWNER_ADDRESS)
+        .to(SC_ADDRESS)
+        .typed(my_proxy::MyProxy)
+        .add(1u32)
+        .run();
+
+    // Verify storage
+    world.check_account(SC_ADDRESS).check_storage("str:sum", "6");
+
+    world.write_scenario_trace("scenarios/trace1.scen.json");
+}
+\`\`\``,
+    {
+      title: 'Blackbox Testing with ScenarioWorld (Modern API)',
+      description:
+        'Modern recommended approach for blackbox contract testing using ScenarioWorld with .tx()/.query() fluent builder, typed proxy, and scenario trace generation',
+      tags: [
+        'testing',
+        'blackbox',
+        'ScenarioWorld',
+        'tx',
+        'query',
+        'proxy',
+        'deploy',
+        'upgrade',
+        'trace',
+        'modern',
+      ],
+      language: 'rust',
+      relevanceScore: 0.97,
+      contractType: 'any',
+      author: 'klever-mcp',
+    }
+  ),
+
+  createKnowledgeEntry(
+    'code_example',
+    `# Blackbox Testing with Raw Steps (Step-Based API)
+
+The raw steps API gives full control over each blockchain action using explicit step objects. Useful when you need precise control or are migrating from scenario JSON files.
+
+## Setup
+
+\`\`\`rust
+use klever_sc_scenario::imports::*;
+
+const SC_PATH: &str = "kleversc:output/my-contract.kleversc.json";
+
+fn world() -> ScenarioWorld {
+    let mut blockchain = ScenarioWorld::new();
+    blockchain.register_contract(SC_PATH, my_contract::ContractBuilder);
+    blockchain
+}
+\`\`\`
+
+## Deploy with SetStateStep + ScDeployStep
+
+\`\`\`rust
+#[test]
+fn deploy_raw_test() {
+    let mut world = world();
+    let code = world.code_expression(SC_PATH);
+
+    world
+        .set_state_step(
+            SetStateStep::new()
+                .put_account("address:owner", Account::new().nonce(1))
+                .new_address("address:owner", 2, "sc:my-contract"),
+        )
+        .sc_deploy(
+            ScDeployStep::new()
+                .from("address:owner")
+                .code(code)
+                .argument("5")                       // constructor arg (raw)
+                .gas_limit("5,000,000")
+                .expect(TxExpect::ok().no_result()),  // assert no return value
+        );
+}
+\`\`\`
+
+## Query with ScQueryStep
+
+\`\`\`rust
+world.sc_query(
+    ScQueryStep::new()
+        .to("sc:my-contract")
+        .function("getSum")
+        .expect(TxExpect::ok().result("5")),     // assert return = 5
+);
+\`\`\`
+
+## Call with ScCallStep
+
+\`\`\`rust
+world.sc_call(
+    ScCallStep::new()
+        .from("address:owner")
+        .to("sc:my-contract")
+        .function("add")
+        .argument("3")
+        .expect(TxExpect::ok().no_result()),
+);
+\`\`\`
+
+## Check State with CheckStateStep
+
+\`\`\`rust
+world.check_state_step(
+    CheckStateStep::new()
+        .put_account("address:owner", CheckAccount::new())
+        .put_account(
+            "sc:my-contract",
+            CheckAccount::new().check_storage("str:sum", "8"),
+        ),
+);
+\`\`\`
+
+## Multi-Token Payment in ScCallStep
+
+\`\`\`rust
+world.sc_call(
+    ScCallStep::new()
+        .from("address:an-account")
+        .to("sc:my-contract")
+        .function("echo_call_value")
+        .kda_transfer("str:TOK-000001", 0, "100")   // fungible token
+        .kda_transfer("str:TOK-000002", 0, "400")
+        .expect(
+            TxExpect::ok()
+                .result("0")
+                .result("nested:str:TOK-000001|u64:0|biguint:100|nested:str:TOK-000002|u64:0|biguint:400"),
+        ),
+);
+\`\`\`
+
+## Contract Upgrade via ScCallStep
+
+\`\`\`rust
+world.sc_call(
+    ScCallStep::new()
+        .from("address:owner")
+        .to("sc:my-contract")
+        .function("upgradeContract")
+        .argument(&new_code)         // new wasm code
+        .argument("0x0502")          // codeMetadata
+        .argument("8")               // new constructor arg
+        .expect(TxExpect::ok().no_result()),
+);
+\`\`\`
+
+## Deploy and Capture Address
+
+\`\`\`rust
+let owner_address = "address:owner";
+let mut contract = ContractInfo::<my_contract::Proxy<StaticApi>>::new("sc:my-contract");
+
+world
+    .sc_deploy_use_result(
+        ScDeployStep::new()
+            .from(owner_address)
+            .code(code)
+            .call(contract.init()),
+        |address, tr: TypedResponse<String>| {
+            assert_eq!(address, contract.to_address());
+            assert_eq!(tr.result.unwrap(), "constructor-result");
+        },
+    );
+\`\`\`
+
+## Account Setup with KDA Balances
+
+\`\`\`rust
+world.set_state_step(
+    SetStateStep::new()
+        .put_account(
+            "address:user",
+            Account::new()
+                .balance("10000")
+                .kda_balance("str:TOK-000001", "1000")
+                .kda_nft_balance("str:NFT-abc123", 5u32, 10u32, Option::<()>::None),
+        )
+        .put_account("sc:my-contract", Account::new().code(code)),
+);
+\`\`\``,
+    {
+      title: 'Blackbox Testing with Raw Step Objects',
+      description:
+        'Step-based blackbox testing API using SetStateStep, ScDeployStep, ScCallStep, ScQueryStep, and CheckStateStep for precise blockchain simulation',
+      tags: [
+        'testing',
+        'blackbox',
+        'raw-steps',
+        'ScDeployStep',
+        'ScCallStep',
+        'ScQueryStep',
+        'CheckStateStep',
+        'SetStateStep',
+        'kda-transfer',
+      ],
+      language: 'rust',
+      relevanceScore: 0.92,
+      contractType: 'any',
+      author: 'klever-mcp',
+    }
+  ),
+];
+
+export default blackboxTestsKnowledge;

--- a/src/knowledge/testing/blackbox-tests.ts
+++ b/src/knowledge/testing/blackbox-tests.ts
@@ -20,8 +20,11 @@ use klever_sc_scenario::imports::*;
 use my_contract::*;  // imports your contract + proxy
 
 const OWNER_ADDRESS: TestAddress = TestAddress::new("owner");
+const OTHER_ADDRESS: TestAddress = TestAddress::new("other");
+const USER_ADDRESS: TestAddress = TestAddress::new("user");
 const SC_ADDRESS: TestSCAddress = TestSCAddress::new("my-contract");
 const CODE_PATH: KleverscPath = KleverscPath::new("output/my-contract.kleversc.json");
+const TOKEN_ID: TestTokenIdentifier = TestTokenIdentifier::new("TOKEN-abc123");
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
@@ -134,7 +137,7 @@ let value = world
     .multi_return(1u32)
     .returns(ReturnsResultUnmanaged)
     .run();
-assert_eq!(value, MultiValue2((RustBigUint::from(1u32), RustBigUint::from(2u32))));
+assert_eq!(value, MultiValue2((1u32, 2u32)));
 \`\`\`
 
 ## Testing Upgrade
@@ -193,7 +196,7 @@ fn full_lifecycle_test() {
     world
         .tx()
         .from(OWNER_ADDRESS)
-        .typed(my_proxy::MyProxy)
+        .typed(my_contract_proxy::MyContractProxy)
         .init(5u32)
         .code(CODE_PATH)
         .new_address(SC_ADDRESS)
@@ -203,7 +206,7 @@ fn full_lifecycle_test() {
     world
         .query()
         .to(SC_ADDRESS)
-        .typed(my_proxy::MyProxy)
+        .typed(my_contract_proxy::MyContractProxy)
         .sum()
         .returns(ExpectValue(5u32))
         .run();
@@ -213,7 +216,7 @@ fn full_lifecycle_test() {
         .tx()
         .from(OWNER_ADDRESS)
         .to(SC_ADDRESS)
-        .typed(my_proxy::MyProxy)
+        .typed(my_contract_proxy::MyContractProxy)
         .add(1u32)
         .run();
 
@@ -364,7 +367,10 @@ world.sc_call(
 ## Deploy and Capture Address
 
 \`\`\`rust
+use klever_sc_scenario::api::StaticApi;
+
 let owner_address = "address:owner";
+let code = world.code_expression(SC_PATH);
 let mut contract = ContractInfo::<my_contract::Proxy<StaticApi>>::new("sc:my-contract");
 
 world

--- a/src/knowledge/testing/blackbox-tests.ts
+++ b/src/knowledge/testing/blackbox-tests.ts
@@ -76,6 +76,7 @@ world
     .run();
 
 // Or capture the return value
+// (RustBigUint is re-exported by klever_sc_scenario::imports::*)
 let value = world
     .query()
     .to(SC_ADDRESS)

--- a/src/knowledge/testing/index.ts
+++ b/src/knowledge/testing/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Testing knowledge — unit, whitebox, blackbox, and scenario JSON patterns
+ */
+
+import unitTestsKnowledge from './unit-tests.js';
+import whiteboxTestsKnowledge from './whitebox-tests.js';
+import blackboxTestsKnowledge from './blackbox-tests.js';
+import scenarioJsonKnowledge from './scenario-json.js';
+
+export const testingKnowledge = [
+  ...unitTestsKnowledge,
+  ...whiteboxTestsKnowledge,
+  ...blackboxTestsKnowledge,
+  ...scenarioJsonKnowledge,
+];
+
+export default testingKnowledge;

--- a/src/knowledge/testing/scenario-json.ts
+++ b/src/knowledge/testing/scenario-json.ts
@@ -212,7 +212,7 @@ fn interactor_trace_rs() {
         'trace',
         'interactor',
       ],
-      language: 'json',
+      language: 'markdown',
       relevanceScore: 0.91,
       contractType: 'any',
       author: 'klever-mcp',

--- a/src/knowledge/testing/scenario-json.ts
+++ b/src/knowledge/testing/scenario-json.ts
@@ -1,0 +1,223 @@
+import { createKnowledgeEntry, KnowledgeEntry } from '../types.js';
+
+export const scenarioJsonKnowledge: KnowledgeEntry[] = [
+  createKnowledgeEntry(
+    'code_example',
+    `# Scenario JSON Files (.scen.json)
+
+Scenario files are JSON-based integration tests that run on both the Rust VM and the Go VM. They are the most portable test format and can be generated automatically from Rust blackbox tests.
+
+## Running Scenario Files from Rust
+
+\`\`\`rust
+// tests/my_contract_scenario_rs_test.rs
+use klever_sc_scenario::*;
+
+fn world() -> ScenarioWorld {
+    let mut blockchain = ScenarioWorld::new();
+    blockchain.register_contract(
+        "kleversc:output/my-contract.kleversc.json",
+        my_contract::ContractBuilder,
+    );
+    blockchain
+}
+
+#[test]
+fn my_scenario_rs() {
+    world().run("scenarios/my-scenario.scen.json");
+}
+\`\`\`
+
+## Scenario File Structure
+
+\`\`\`json
+{
+    "name": "my contract test",
+    "comment": "deploys, calls, and checks state",
+    "gasSchedule": "dummy",
+    "steps": [
+        {
+            "step": "setState",
+            "accounts": {
+                "address:owner": {
+                    "nonce": "1",
+                    "balance": "0"
+                }
+            },
+            "newAddresses": [
+                {
+                    "creatorAddress": "address:owner",
+                    "creatorNonce": "2",
+                    "newAddress": "sc:my-contract"
+                }
+            ]
+        },
+        {
+            "step": "scDeploy",
+            "id": "deploy",
+            "tx": {
+                "from": "address:owner",
+                "contractCode": "kleversc:output/my-contract.kleversc.json",
+                "arguments": ["5"],
+                "gasLimit": "5,000,000",
+                "gasPrice": "0"
+            },
+            "expect": {
+                "out": [],
+                "status": "",
+                "logs": "*",
+                "gas": "*",
+                "refund": "*"
+            }
+        },
+        {
+            "step": "scQuery",
+            "id": "query-initial",
+            "tx": {
+                "to": "sc:my-contract",
+                "function": "getSum",
+                "arguments": []
+            },
+            "expect": {
+                "out": ["5"],
+                "status": "",
+                "logs": []
+            }
+        },
+        {
+            "step": "scCall",
+            "id": "call-add",
+            "tx": {
+                "from": "address:owner",
+                "to": "sc:my-contract",
+                "function": "add",
+                "arguments": ["3"],
+                "gasLimit": "5,000,000",
+                "gasPrice": "0"
+            },
+            "expect": {
+                "out": [],
+                "status": "",
+                "logs": "*",
+                "gas": "*",
+                "refund": "*"
+            }
+        },
+        {
+            "step": "checkState",
+            "accounts": {
+                "address:owner": {
+                    "nonce": "*",
+                    "balance": "0",
+                    "storage": {},
+                    "code": ""
+                },
+                "sc:my-contract": {
+                    "nonce": "0",
+                    "balance": "0",
+                    "storage": {
+                        "str:sum": "8"
+                    },
+                    "code": "kleversc:output/my-contract.kleversc.json"
+                }
+            }
+        }
+    ]
+}
+\`\`\`
+
+## Step Types
+
+| Step | Purpose |
+|------|---------|
+| \`setState\` | Set up accounts, balances, storage, and address mappings |
+| \`scDeploy\` | Deploy a contract |
+| \`scCall\` | Call a contract endpoint |
+| \`scQuery\` | Read-only query to a contract |
+| \`checkState\` | Assert on account state (balances, storage, nonce) |
+| \`transfer\` | Transfer KLV/KDA between accounts |
+
+## Value Encoding in JSON
+
+| Value | Example |
+|-------|---------|
+| Decimal number | \`"100"\` |
+| Hex | \`"0x0502"\` |
+| String | \`"str:my-key"\` |
+| Nested encoded | \`"nested:str:TOKEN|u64:0|biguint:100"\` |
+| Wildcard (any) | \`"*"\` |
+| Empty/zero | \`""\` or \`"0"\` |
+
+## Generating Scenario Files from Rust Tests
+
+Rust tests can write \`.scen.json\` trace files automatically:
+
+\`\`\`rust
+#[test]
+fn generate_trace() {
+    let mut world = world();
+
+    world.start_trace();   // start recording
+
+    world.account(OWNER_ADDRESS).nonce(1).commit();
+
+    world
+        .tx()
+        .from(OWNER_ADDRESS)
+        .typed(my_proxy::MyProxy)
+        .init(5u32)
+        .code(CODE_PATH)
+        .new_address(SC_ADDRESS)
+        .run();
+
+    // ... more steps ...
+
+    world.write_scenario_trace("scenarios/generated-trace.scen.json");
+}
+\`\`\`
+
+The output file can then be replayed:
+
+\`\`\`rust
+#[test]
+fn replay_trace_rs() {
+    world().run("scenarios/generated-trace.scen.json");
+}
+\`\`\`
+
+## Interactor Traces
+
+Interactor traces are scenario files generated by on-chain interactors (scripts). They capture real blockchain interactions and can be replayed in tests:
+
+\`\`\`rust
+#[test]
+fn interactor_trace_rs() {
+    world().run("scenarios/interactor_trace.scen.json");
+}
+\`\`\``,
+    {
+      title: 'Scenario JSON Files (.scen.json)',
+      description:
+        'How to write, structure, and replay .scen.json scenario files for portable VM-independent contract testing, including trace generation from Rust tests',
+      tags: [
+        'testing',
+        'scenario',
+        'scen.json',
+        'json',
+        'setState',
+        'scDeploy',
+        'scCall',
+        'scQuery',
+        'checkState',
+        'trace',
+        'interactor',
+      ],
+      language: 'json',
+      relevanceScore: 0.91,
+      contractType: 'any',
+      author: 'klever-mcp',
+    }
+  ),
+];
+
+export default scenarioJsonKnowledge;

--- a/src/knowledge/testing/scenario-json.ts
+++ b/src/knowledge/testing/scenario-json.ts
@@ -212,7 +212,7 @@ fn interactor_trace_rs() {
         'trace',
         'interactor',
       ],
-      language: 'markdown',
+      language: 'rust',
       relevanceScore: 0.91,
       contractType: 'any',
       author: 'klever-mcp',

--- a/src/knowledge/testing/unit-tests.ts
+++ b/src/knowledge/testing/unit-tests.ts
@@ -17,7 +17,7 @@ Unit tests are the fastest test type — no blockchain simulation, no state setu
 Add to \`Cargo.toml\`:
 \`\`\`toml
 [dev-dependencies]
-klever-sc-scenario = { version = "0.x" }
+klever-sc-scenario = { version = "0.*" }
 \`\`\`
 
 ## Basic Unit Test

--- a/src/knowledge/testing/unit-tests.ts
+++ b/src/knowledge/testing/unit-tests.ts
@@ -1,0 +1,85 @@
+import { createKnowledgeEntry, KnowledgeEntry } from '../types.js';
+
+export const unitTestsKnowledge: KnowledgeEntry[] = [
+  createKnowledgeEntry(
+    'code_example',
+    `# Unit Testing Smart Contracts with SingleTxApi
+
+Unit tests are the fastest test type — no blockchain simulation, no state setup. They call contract functions directly using \`SingleTxApi\`.
+
+## When to Use
+- Testing pure logic (math, transformations, state reads/writes)
+- Fast feedback loops during development
+- No cross-contract calls, no KLV/KDA payments needed
+
+## Setup
+
+Add to \`Cargo.toml\`:
+\`\`\`toml
+[dev-dependencies]
+klever-sc-scenario = { version = "0.x" }
+\`\`\`
+
+## Basic Unit Test
+
+\`\`\`rust
+use adder::*;
+use klever_sc::types::BigUint;
+use klever_sc_scenario::api::SingleTxApi;
+
+#[test]
+fn adder_unit_test() {
+    // Create contract object directly — no blockchain simulation
+    let contract = adder::contract_obj::<SingleTxApi>();
+
+    // Call init (simulates deploy constructor)
+    contract.init(BigUint::from(5u32));
+    assert_eq!(BigUint::from(5u32), contract.sum().get());
+
+    // Call endpoint
+    contract.add(BigUint::from(7u32));
+    assert_eq!(BigUint::from(12u32), contract.sum().get());
+
+    contract.add(BigUint::from(1u32));
+    assert_eq!(BigUint::from(13u32), contract.sum().get());
+}
+\`\`\`
+
+## Accessing Storage Directly
+
+\`\`\`rust
+#[test]
+fn storage_direct_test() {
+    let contract = my_contract::contract_obj::<SingleTxApi>();
+
+    contract.init(BigUint::from(100u32));
+
+    // Read storage mapper directly
+    let stored = contract.my_value().get();
+    assert_eq!(stored, BigUint::from(100u32));
+
+    // Write storage mapper directly (no tx needed)
+    contract.my_value().set(BigUint::from(200u32));
+    assert_eq!(contract.my_value().get(), BigUint::from(200u32));
+}
+\`\`\`
+
+## Limitations
+- Cannot test \`#[payable]\` endpoints (no KLV/KDA transfers)
+- Cannot test blockchain state queries (caller, epoch, etc.)
+- Cannot test cross-contract calls
+- Use whitebox or blackbox tests for those scenarios`,
+    {
+      title: 'Unit Testing Smart Contracts with SingleTxApi',
+      description:
+        'How to write fast unit tests for Klever smart contracts using SingleTxApi without blockchain simulation',
+      tags: ['testing', 'unit-test', 'SingleTxApi', 'contract_obj', 'no-simulation'],
+      language: 'rust',
+      relevanceScore: 0.93,
+      contractType: 'any',
+      author: 'klever-mcp',
+    }
+  ),
+];
+
+export default unitTestsKnowledge;

--- a/src/knowledge/testing/whitebox-tests.ts
+++ b/src/knowledge/testing/whitebox-tests.ts
@@ -16,6 +16,7 @@ Whitebox tests give you access to contract internals while simulating a full blo
 ## Setup
 
 \`\`\`rust
+use klever_sc::codec::Empty;
 use klever_sc_scenario::{
     testing_framework::*, rust_biguint, managed_biguint, managed_token_id, managed_address,
 };
@@ -56,7 +57,7 @@ fn execute_tx_test() {
     // Simulate deploy by calling init
     wrapper
         .execute_tx(&user, &sc, &rust_biguint!(0), |sc| {
-            sc.init();
+            sc.init(managed_biguint!(1));
         })
         .assert_ok();
 
@@ -146,6 +147,7 @@ fn test_nft() {
     let sc = wrapper.create_sc_account(&rust_biguint!(0), None, my_contract::contract_obj, WASM_PATH);
     let token_id = b"NFT-abc123";
     let nonce = 2u64;
+    let nft_attrs = Empty;
 
     wrapper.set_nft_balance(sc.address_ref(), token_id, nonce, &rust_biguint!(1_000), &nft_attrs);
     wrapper.check_nft_balance(sc.address_ref(), token_id, nonce, &rust_biguint!(1_000), Some(&nft_attrs));
@@ -220,7 +222,7 @@ fn storage_revert_on_error_test() {
     let user = wrapper.create_user_account(&rust_biguint!(0));
     let sc = wrapper.create_sc_account(&rust_biguint!(0), None, my_contract::contract_obj, WASM_PATH);
 
-    wrapper.execute_tx(&user, &sc, &rust_biguint!(0), |sc| { sc.init(); }).assert_ok();
+    wrapper.execute_tx(&user, &sc, &rust_biguint!(0), |sc| { sc.init(managed_biguint!(1)); }).assert_ok();
 
     // This tx panics — ALL storage changes inside must be reverted
     wrapper
@@ -264,6 +266,12 @@ fn blockchain_state_test() {
 ## Whitebox Style (WhiteboxContract)
 
 \`\`\`rust
+fn world() -> ScenarioWorld {
+    let mut blockchain = ScenarioWorld::new();
+    blockchain.register_contract("kleversc:output/my-contract.kleversc.json", my_contract::ContractBuilder);
+    blockchain
+}
+
 #[test]
 fn st_whitebox() {
     let mut world = world();

--- a/src/knowledge/testing/whitebox-tests.ts
+++ b/src/knowledge/testing/whitebox-tests.ts
@@ -3,9 +3,9 @@ import { createKnowledgeEntry, KnowledgeEntry } from '../types.js';
 export const whiteboxTestsKnowledge: KnowledgeEntry[] = [
   createKnowledgeEntry(
     'code_example',
-    `# Whitebox Testing with BlockchainStateWrapper (Legacy)
+    `# Whitebox Testing with BlockchainStateWrapper
 
-Whitebox tests give you access to contract internals while simulating a full blockchain environment. The \`BlockchainStateWrapper\` API is the older style — still fully supported.
+Whitebox tests give you access to contract internals while simulating a full blockchain environment. The \`BlockchainStateWrapper\` API is the original whitebox style and is fully supported. For new contracts, also consider the \`ScenarioWorld\`-based whitebox API (see "Whitebox Style (WhiteboxContract)" below).
 
 ## When to Use
 - Need to inspect/modify storage directly during a test

--- a/src/knowledge/testing/whitebox-tests.ts
+++ b/src/knowledge/testing/whitebox-tests.ts
@@ -1,0 +1,321 @@
+import { createKnowledgeEntry, KnowledgeEntry } from '../types.js';
+
+export const whiteboxTestsKnowledge: KnowledgeEntry[] = [
+  createKnowledgeEntry(
+    'code_example',
+    `# Whitebox Testing with BlockchainStateWrapper (Legacy)
+
+Whitebox tests give you access to contract internals while simulating a full blockchain environment. The \`BlockchainStateWrapper\` API is the older style — still fully supported.
+
+## When to Use
+- Need to inspect/modify storage directly during a test
+- Testing payment flows (KLV and KDA)
+- Testing blockchain state queries (epoch, nonce, timestamp)
+- Testing events and state revert behavior
+
+## Setup
+
+\`\`\`rust
+use klever_sc_scenario::{
+    testing_framework::*, rust_biguint, managed_biguint, managed_token_id, managed_address,
+};
+use my_contract::*;
+
+const WASM_PATH: &str = "output/my-contract.wasm";
+\`\`\`
+
+## Creating Accounts and Contracts
+
+\`\`\`rust
+#[test]
+fn setup_test() {
+    let mut wrapper = BlockchainStateWrapper::new();
+
+    // Create a user wallet with KLV balance
+    let user = wrapper.create_user_account(&rust_biguint!(1_000));
+
+    // Create a smart contract account (owner = user)
+    let sc = wrapper.create_sc_account(
+        &rust_biguint!(0),        // initial KLV balance
+        Some(&user),              // owner (None = no owner)
+        my_contract::contract_obj,
+        WASM_PATH,
+    );
+}
+\`\`\`
+
+## Execute Transaction
+
+\`\`\`rust
+#[test]
+fn execute_tx_test() {
+    let mut wrapper = BlockchainStateWrapper::new();
+    let user = wrapper.create_user_account(&rust_biguint!(0));
+    let sc = wrapper.create_sc_account(&rust_biguint!(0), None, my_contract::contract_obj, WASM_PATH);
+
+    // Simulate deploy by calling init
+    wrapper
+        .execute_tx(&user, &sc, &rust_biguint!(0), |sc| {
+            sc.init();
+        })
+        .assert_ok();
+
+    // Execute a state-changing call
+    wrapper
+        .execute_tx(&user, &sc, &rust_biguint!(0), |sc| {
+            sc.add(managed_biguint!(50));
+            // Can assert storage changes inside the closure
+            assert_eq!(sc.total_value().get(), managed_biguint!(51));
+        })
+        .assert_ok();
+}
+\`\`\`
+
+## Execute Query (Read-Only)
+
+\`\`\`rust
+#[test]
+fn execute_query_test() {
+    let mut wrapper = BlockchainStateWrapper::new();
+    let sc = wrapper.create_sc_account(&rust_biguint!(2_000), None, my_contract::contract_obj, WASM_PATH);
+
+    wrapper
+        .execute_query(&sc, |sc| {
+            let balance = sc.get_klv_balance();
+            assert_eq!(balance, managed_biguint!(2_000));
+        })
+        .assert_ok();
+}
+\`\`\`
+
+## Testing KLV Payments
+
+\`\`\`rust
+#[test]
+fn test_klv_payment() {
+    let mut wrapper = BlockchainStateWrapper::new();
+    let caller = wrapper.create_user_account(&rust_biguint!(1_000));
+    let sc = wrapper.create_sc_account(&rust_biguint!(2_000), Some(&caller), my_contract::contract_obj, WASM_PATH);
+
+    // Send KLV with the transaction
+    wrapper
+        .execute_tx(&caller, &sc, &rust_biguint!(1_000), |sc| {
+            let payment = sc.receive_klv();
+            assert_eq!(payment, managed_biguint!(1_000));
+        })
+        .assert_ok();
+
+    // Check balances after tx
+    wrapper.check_klv_balance(&caller, &rust_biguint!(0));
+    wrapper.check_klv_balance(sc.address_ref(), &rust_biguint!(3_000));
+}
+\`\`\`
+
+## Testing KDA Token Transfers
+
+\`\`\`rust
+#[test]
+fn test_kda_transfer() {
+    let mut wrapper = BlockchainStateWrapper::new();
+    let caller = wrapper.create_user_account(&rust_biguint!(0));
+    let sc = wrapper.create_sc_account(&rust_biguint!(0), None, my_contract::contract_obj, WASM_PATH);
+    let token_id = b"COOL-123456";
+
+    wrapper.set_kda_balance(&caller, token_id, &rust_biguint!(1_000));
+    wrapper.set_kda_balance(sc.address_ref(), token_id, &rust_biguint!(2_000));
+
+    wrapper
+        .execute_kda_transfer(&caller, &sc, token_id, 0, &rust_biguint!(1_000), |sc| {
+            let (id, amount) = sc.receive_kda();
+            assert_eq!(id, managed_token_id!(token_id));
+            assert_eq!(amount, managed_biguint!(1_000));
+        })
+        .assert_ok();
+
+    wrapper.check_kda_balance(&caller, token_id, &rust_biguint!(0));
+    wrapper.check_kda_balance(sc.address_ref(), token_id, &rust_biguint!(3_000));
+}
+\`\`\`
+
+## Testing NFT Balances
+
+\`\`\`rust
+#[test]
+fn test_nft() {
+    let mut wrapper = BlockchainStateWrapper::new();
+    let sc = wrapper.create_sc_account(&rust_biguint!(0), None, my_contract::contract_obj, WASM_PATH);
+    let token_id = b"NFT-abc123";
+    let nonce = 2u64;
+
+    wrapper.set_nft_balance(sc.address_ref(), token_id, nonce, &rust_biguint!(1_000), &nft_attrs);
+    wrapper.check_nft_balance(sc.address_ref(), token_id, nonce, &rust_biguint!(1_000), Some(&nft_attrs));
+}
+\`\`\`
+
+## Testing Multi-Token Transfers
+
+\`\`\`rust
+#[test]
+fn test_multi_transfer() {
+    let mut wrapper = BlockchainStateWrapper::new();
+    let caller = wrapper.create_user_account(&rust_biguint!(0));
+    let sc = wrapper.create_sc_account(&rust_biguint!(0), None, my_contract::contract_obj, WASM_PATH);
+
+    wrapper.set_kda_balance(&caller, b"TOK1-111111", &rust_biguint!(100));
+    wrapper.set_nft_balance(&caller, b"NFT1-222222", 5, &rust_biguint!(1), &Empty);
+
+    let transfers = vec![
+        TxTokenTransfer { token_identifier: b"TOK1-111111".to_vec(), nonce: 0, value: rust_biguint!(100) },
+        TxTokenTransfer { token_identifier: b"NFT1-222222".to_vec(), nonce: 5, value: rust_biguint!(1) },
+    ];
+
+    wrapper
+        .execute_kda_multi_transfer(&caller, &sc, &transfers, |sc| {
+            let payments = sc.receive_multi_kda().into_vec();
+            assert_eq!(payments.len(), 2);
+        })
+        .assert_ok();
+}
+\`\`\`
+
+## Testing Error Cases
+
+\`\`\`rust
+#[test]
+fn test_error_on_zero_input() {
+    let mut wrapper = BlockchainStateWrapper::new();
+    let user = wrapper.create_user_account(&rust_biguint!(0));
+    let sc = wrapper.create_sc_account(&rust_biguint!(0), None, my_contract::contract_obj, WASM_PATH);
+
+    wrapper
+        .execute_query(&sc, |sc| {
+            let _ = sc.sum_sc_result(managed_biguint!(0), managed_biguint!(2000));
+        })
+        .assert_user_error("Non-zero required");
+}
+
+#[test]
+fn test_payment_rejected() {
+    let mut wrapper = BlockchainStateWrapper::new();
+    let caller = wrapper.create_user_account(&rust_biguint!(1_000));
+    let sc = wrapper.create_sc_account(&rust_biguint!(0), Some(&caller), my_contract::contract_obj, WASM_PATH);
+
+    // Transaction reverted — balances unchanged
+    wrapper
+        .execute_tx(&caller, &sc, &rust_biguint!(1_000), |sc| {
+            sc.reject_payment();
+        })
+        .assert_user_error("No payment allowed!");
+
+    wrapper.check_klv_balance(&caller, &rust_biguint!(1_000));
+}
+\`\`\`
+
+## Testing Storage Revert on Panic
+
+\`\`\`rust
+#[test]
+fn storage_revert_on_error_test() {
+    let mut wrapper = BlockchainStateWrapper::new();
+    let user = wrapper.create_user_account(&rust_biguint!(0));
+    let sc = wrapper.create_sc_account(&rust_biguint!(0), None, my_contract::contract_obj, WASM_PATH);
+
+    wrapper.execute_tx(&user, &sc, &rust_biguint!(0), |sc| { sc.init(); }).assert_ok();
+
+    // This tx panics — ALL storage changes inside must be reverted
+    wrapper
+        .execute_tx(&user, &sc, &rust_biguint!(0), |sc| {
+            sc.add(managed_biguint!(50));   // This change is reverted
+            sc.panic();                     // Triggers revert
+        })
+        .assert_user_error("Oh no!");
+
+    // Value should still be the initial one, not 51
+    wrapper
+        .execute_query(&sc, |sc| {
+            assert_eq!(sc.total_value().get(), managed_biguint!(1));
+        })
+        .assert_ok();
+}
+\`\`\`
+
+## Testing Blockchain State
+
+\`\`\`rust
+#[test]
+fn blockchain_state_test() {
+    let mut wrapper = BlockchainStateWrapper::new();
+    let sc = wrapper.create_sc_account(&rust_biguint!(0), None, my_contract::contract_obj, WASM_PATH);
+
+    wrapper.set_block_epoch(10);
+    wrapper.set_block_nonce(20);
+    wrapper.set_block_timestamp(30);
+
+    wrapper
+        .execute_query(&sc, |sc| {
+            assert_eq!(sc.get_block_epoch(), 10);
+            assert_eq!(sc.get_block_nonce(), 20);
+            assert_eq!(sc.get_block_timestamp(), 30);
+        })
+        .assert_ok();
+}
+\`\`\`
+
+## Whitebox Style (WhiteboxContract)
+
+\`\`\`rust
+#[test]
+fn st_whitebox() {
+    let mut world = world();
+    let contract_wb = WhiteboxContract::new("sc:my-contract", my_contract::contract_obj);
+    let code = world.code_expression("kleversc:output/my-contract.kleversc.json");
+
+    world
+        .set_state_step(
+            SetStateStep::new()
+                .put_account("address:owner", Account::new().nonce(1))
+                .new_address("address:owner", 2, "sc:my-contract"),
+        )
+        .whitebox_deploy(
+            &contract_wb,
+            ScDeployStep::new().from("address:owner").code(code),
+            |sc| { sc.init(5u32.into()); },
+        )
+        .whitebox_query(&contract_wb, |sc| {
+            assert_eq!(sc.sum().get(), 5u32);
+        })
+        .whitebox_call(
+            &contract_wb,
+            ScCallStep::new().from("address:owner"),
+            |sc| sc.add(3u32.into()),
+        )
+        .check_state_step(
+            CheckStateStep::new()
+                .put_account("sc:my-contract", CheckAccount::new().check_storage("str:sum", "8")),
+        );
+}
+\`\`\``,
+    {
+      title: 'Whitebox Testing with BlockchainStateWrapper',
+      description:
+        'Full guide to whitebox testing: payments, KDA transfers, NFTs, error cases, storage revert, and blockchain state manipulation',
+      tags: [
+        'testing',
+        'whitebox',
+        'BlockchainStateWrapper',
+        'execute_tx',
+        'execute_query',
+        'kda',
+        'payments',
+        'nft',
+        'revert',
+      ],
+      language: 'rust',
+      relevanceScore: 0.96,
+      contractType: 'any',
+      author: 'klever-mcp',
+    }
+  ),
+];
+
+export default whiteboxTestsKnowledge;

--- a/src/mcp/resources.test.ts
+++ b/src/mcp/resources.test.ts
@@ -114,8 +114,8 @@ describe('MCP Resources', () => {
   });
 
   describe('KNOWLEDGE_CATEGORIES', () => {
-    it('contains all 11 categories', () => {
-      expect(KNOWLEDGE_CATEGORIES).toHaveLength(11);
+    it('contains all 12 categories', () => {
+      expect(KNOWLEDGE_CATEGORIES).toHaveLength(12);
       expect(KNOWLEDGE_CATEGORIES).toContain('core');
       expect(KNOWLEDGE_CATEGORIES).toContain('storage');
       expect(KNOWLEDGE_CATEGORIES).toContain('events');
@@ -127,6 +127,7 @@ describe('MCP Resources', () => {
       expect(KNOWLEDGE_CATEGORIES).toContain('errors');
       expect(KNOWLEDGE_CATEGORIES).toContain('best-practices');
       expect(KNOWLEDGE_CATEGORIES).toContain('documentation');
+      expect(KNOWLEDGE_CATEGORIES).toContain('testing');
     });
   });
 });

--- a/src/mcp/resources.test.ts
+++ b/src/mcp/resources.test.ts
@@ -1,5 +1,6 @@
 import { ContextService } from '../context/service.js';
 import { InMemoryStorage } from '../storage/memory.js';
+import { testingKnowledge } from '../knowledge/index.js';
 import {
   getResourceTemplates,
   getStaticResources,
@@ -133,6 +134,18 @@ describe('MCP Resources', () => {
       await expect(
         readResource('klever://knowledge/nonexistent', contextService)
       ).rejects.toThrow('Unknown knowledge category');
+    });
+  });
+
+  describe('testingKnowledge module', () => {
+    it('exports at least one entry per testing subcategory', () => {
+      expect(testingKnowledge.length).toBeGreaterThanOrEqual(4);
+    });
+
+    it('tags every entry with "testing" so the category resource picks them up', () => {
+      for (const entry of testingKnowledge) {
+        expect(entry.metadata.tags).toContain('testing');
+      }
     });
   });
 

--- a/src/mcp/resources.test.ts
+++ b/src/mcp/resources.test.ts
@@ -44,6 +44,21 @@ describe('MCP Resources', () => {
       },
       relatedContextIds: [],
     });
+
+    await contextService.ingest({
+      type: 'code_example',
+      content: 'use klever_sc_scenario::imports::*;',
+      metadata: {
+        title: 'Blackbox Testing Example',
+        description: 'Example blackbox test using ScenarioWorld',
+        tags: ['testing', 'blackbox', 'ScenarioWorld'],
+        language: 'rust',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        relevanceScore: 0.95,
+      },
+      relatedContextIds: [],
+    });
   });
 
   describe('getResourceTemplates', () => {
@@ -98,6 +113,14 @@ describe('MCP Resources', () => {
       const result = await readResource('klever://knowledge/best-practices', contextService);
       expect(result.text).toContain('# Klever Knowledge: best-practices');
       expect(result.text).toContain('Event Best Practice');
+    });
+
+    it('returns entries for testing category', async () => {
+      const result = await readResource('klever://knowledge/testing', contextService);
+      expect(result.uri).toBe('klever://knowledge/testing');
+      expect(result.mimeType).toBe('text/markdown');
+      expect(result.text).toContain('# Klever Knowledge: testing');
+      expect(result.text).toContain('Blackbox Testing Example');
     });
 
     it('throws error for invalid URI format', async () => {

--- a/src/mcp/resources.ts
+++ b/src/mcp/resources.ts
@@ -38,7 +38,17 @@ export const CATEGORY_TAG_MAP: Record<KnowledgeCategory, string[]> = {
   errors: ['errors', 'error', 'common-mistakes', 'pitfalls'],
   'best-practices': ['best-practices', 'best_practice', 'security', 'optimization'],
   documentation: ['documentation', 'docs', 'guide', 'reference'],
-  testing: ['testing', 'unit-test', 'whitebox', 'blackbox', 'scenario', 'ScenarioWorld', 'BlockchainStateWrapper', 'SingleTxApi', 'scen.json'],
+  testing: [
+    'testing',
+    'unit-test',
+    'whitebox',
+    'blackbox',
+    'scenario',
+    'ScenarioWorld',
+    'BlockchainStateWrapper',
+    'SingleTxApi',
+    'scen.json',
+  ],
 };
 
 /**

--- a/src/mcp/resources.ts
+++ b/src/mcp/resources.ts
@@ -17,6 +17,7 @@ export const KNOWLEDGE_CATEGORIES = [
   'errors',
   'best-practices',
   'documentation',
+  'testing',
 ] as const;
 
 export type KnowledgeCategory = (typeof KNOWLEDGE_CATEGORIES)[number];
@@ -37,6 +38,7 @@ export const CATEGORY_TAG_MAP: Record<KnowledgeCategory, string[]> = {
   errors: ['errors', 'error', 'common-mistakes', 'pitfalls'],
   'best-practices': ['best-practices', 'best_practice', 'security', 'optimization'],
   documentation: ['documentation', 'docs', 'guide', 'reference'],
+  testing: ['testing', 'unit-test', 'whitebox', 'blackbox', 'scenario', 'ScenarioWorld', 'BlockchainStateWrapper', 'SingleTxApi', 'scen.json'],
 };
 
 /**
@@ -147,6 +149,7 @@ async function buildKnowledgeIndex(contextService: ContextService): Promise<stri
     errors: 'Common mistakes, error patterns, and troubleshooting',
     'best-practices': 'Security tips, optimization strategies, and recommended patterns',
     documentation: 'SDK reference, API docs, and developer guides',
+    testing: 'Unit, whitebox, blackbox, and scenario JSON testing patterns',
   };
 
   for (const category of KNOWLEDGE_CATEGORIES) {


### PR DESCRIPTION
This pull request introduces a comprehensive "testing" knowledge category to the Klever knowledge base, providing detailed resources and examples for unit, whitebox, blackbox, and scenario-based testing of smart contracts. The changes add new knowledge entries, update exports and category mappings, and enhance the categorization and discoverability of testing-related documentation.

**Testing Knowledge Base Expansion:**

- Added a new `testing` knowledge category, including detailed guides and code examples for:
  - Unit tests using `SingleTxApi` (`unit-tests.ts`)
  - Whitebox tests with `BlockchainStateWrapper` and related patterns (`whitebox-tests.ts`)
  - Blackbox tests (referenced, but file not shown in this diff)
  - Scenario JSON files for portable, VM-independent contract testing (`scenario-json.ts`)
- Aggregated all testing knowledge in `src/knowledge/testing/index.ts` for unified export

**Knowledge Base Integration:**

- Registered the new `testingKnowledge` in the main knowledge base (`kleverKnowledge`) and exported it for targeted access in `src/knowledge/index.ts` [[1]](diffhunk://#diff-079f20cc8cd29ee62e54c0018219f9cee919de71660971d40506c7036e83605fR20) [[2]](diffhunk://#diff-079f20cc8cd29ee62e54c0018219f9cee919de71660971d40506c7036e83605fR38) [[3]](diffhunk://#diff-079f20cc8cd29ee62e54c0018219f9cee919de71660971d40506c7036e83605fR54)

**MCP Resource Category Updates:**

- Added "testing" to the list of knowledge categories and mapped relevant tags for improved search and categorization in `src/mcp/resources.ts` [[1]](diffhunk://#diff-a5e367d7a53c336d91168c901dab1a43d247566961ca854ec696cf8a4d981a18R20) [[2]](diffhunk://#diff-a5e367d7a53c336d91168c901dab1a43d247566961ca854ec696cf8a4d981a18R41)
- Updated the category description to clarify the scope of testing resources